### PR TITLE
Enhance makefile to support install and uninstall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,5 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=/usr/local/lib/
           export LIBRDB_REDIS_FOLDER=~/redis/src
-          make
+          make all valgrind
         working-directory: ${{github.workspace}}

--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,16 @@ export BUILD_TLS
 endif
 
 # DESTDIR Specifies library installation folder
+LDCONFIG=ldconfig
+PREFIX?=/usr/local
 DESTDIR?=/usr/local/lib
+INSTALL_BIN=$(PREFIX)/bin
 
 all:
 	$(MAKE) -C deps -f Makefile all
 	$(MAKE) -C src/lib -f Makefile all
 	$(MAKE) -C src/ext -f Makefile all
 	$(MAKE) -C src/cli -f Makefile all
-	$(MAKE) -C examples -f Makefile all
-	$(MAKE) -C test -f Makefile all
-	./runtests -v
-
-lib:
-	$(MAKE) -C deps -f Makefile all
-	$(MAKE) -C src/lib -f Makefile all
-	$(MAKE) -C src/ext -f Makefile all
 	$(MAKE) -C examples -f Makefile all
 
 clean:
@@ -40,26 +35,35 @@ example:
 	cd examples && export LD_LIBRARY_PATH=../lib && ./example1
 
 test:
+	$(MAKE) -C test -f Makefile all
 	./runtests
 
 valgrind:
+	$(MAKE) -C test -f Makefile all
 	./runtests -v
 
-install: lib
+install: all
 	cp lib/librdb.so $(DESTDIR)
 	cp lib/librdb-ext.so $(DESTDIR)
+	cp bin/rdb-cli $(INSTALL_BIN)
+	($(LDCONFIG) || true)  >/dev/null 2>&1;
+
+uninstall:
+	rm -f $(DESTDIR)/lib/librdb.so
+	rm -f $(DESTDIR)/lib/librdb-ext.so
+	rm -f $(INSTALL_BIN)/rdb-cli
 
 help:
 	@echo "Target rules:"
 	@echo "    all        - Build parser libraries, tests, and run tests."
-	@echo "    lib        - Build parser libraries."
 	@echo "    test       - Run tests with shared lib."
 	@echo "    valgrind   - Run tests with static lib and valgrind."
 	@echo "    example    - Run the example."
 	@echo "    clean      - Clean without deps folders"
 	@echo "    distclean  - Clean including deps folders"
-	@echo "    install    - Build parser libraries and copy to DESTDIR."
+	@echo "    install    - Build parser libraries and copy to DESTDIR (?=/usr/local/lib)"
+	@echo "    uninstall  - Remove libraries from DESTDIR."
 	@echo "    help       - Prints this message."
 
 
-.PHONY: all clean test help valgrind lib
+.PHONY: all clean test help valgrind install uninstall

--- a/README.md
+++ b/README.md
@@ -27,28 +27,47 @@ running tests (To see parser internal state printouts, execute the command
 
     % make all example
 
-To build and run tests, you need to have cmocka unit testing framework installed and then:
+To build and run tests, you need to have cmocka unit testing framework installed:
 
-    % make all test
+    % make test
 
-Run CLI extension of this library and parse RDB file to json (Requires `make install`):
+Install and run CLI extension of this library. Parse RDB file to json:
 
-    % rdb-cli ./test/dumps/multiple_lists_strings.rdb json
+    % make install
+    % rdb-cli multiple_lists_strings.rdb json
+
+    [{
+    "string2":"Hi there!",
+    "mylist1":["v1"],
+    "mylist3":["v3","v2","v1"],
+    "lzf_compressed":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "string1":"blaa",
+    "mylist2":["v2","v1"]
+    }]
+
 
 Run CLI extension to generate RESP commands
 
     % rdb-cli ./test/dumps/multiple_lists_strings.rdb resp
     *3
-    $5
-    RPUSH
-    $6
+    $3
+    SET
+    $7
+    string2
     ...
 
-Run against live Redis server, say, on address 127.0.0.1:6379, and upload RDB file:
+Run against live Redis server and upload RDB file (example assumes Redis is installed locally):
 
-    % rdb-cli ./test/dumps/multiple_lists_strings.rdb redis -h 127.0.0.1 -p 6379
+    % redis-server --port 6379 & 
+    % rdb-cli multiple_lists_strings.rdb redis -h 127.0.0.1 -p 6379
+    % redis-cli keys "*"
 
-(rdb-cli usage available [here](#rdb-cli usage).)
+    1) "string2"
+    2) "mylist3"
+    3) "mylist2"
+    4) "mylist1"
+    5) "string1"
+    6) "lzf_compressed"
 
 ## Motivation behind this project
 There is a genuine need by the Redis community for a versatile RDB file parser that can

--- a/README.md
+++ b/README.md
@@ -14,39 +14,39 @@ protocols, enabling consumption by various writers. Additionally, a command-line
 
 ## Current status
 The project is currently in its early phase and is considered to be a draft. At present,
-the parser is only capable of handling string and list data types. We are actively seeking
-feedback on the design, API, and implementation to refine the project before proceeding
-with further development. Community contributions are welcome, yet please note that
-the codebase is still undergoing significant changes and may evolve in the future.
+the parser is only capable of handling STRING, LIST, HASH and SET data types. We are 
+actively seeking feedback on the design, API, and implementation to refine the project 
+before proceeding with further development. Community contributions are welcome, yet 
+please note that the codebase is still undergoing significant changes and may evolve in 
+the future.
 
 ## Getting Started
 If you just wish to get a basic understanding of the library's functionality, without
 running tests (To see parser internal state printouts, execute the command
 `export LIBRDB_DEBUG_DATA=1` beforehand):
 
-    % make lib example
+    % make all example
 
 To build and run tests, you need to have cmocka unit testing framework installed and then:
 
-    % make
+    % make all test
 
-Run CLI extension of this library and parse RDB file to json (might need
-`export LD_LIBRARY_PATH=./lib` beforehand):
+Run CLI extension of this library and parse RDB file to json (Requires `make install`):
 
-    % ./bin/rdb-cli ./test/dumps/multiple_lists_strings.rdb json
+    % rdb-cli ./test/dumps/multiple_lists_strings.rdb json
 
 Run CLI extension to generate RESP commands
 
-    % ./bin/rdb-cli ./test/dumps/multiple_lists_strings.rdb resp
+    % rdb-cli ./test/dumps/multiple_lists_strings.rdb resp
     *3
     $5
     RPUSH
     $6
     ...
 
-Run against Redis server, say, on address 127.0.0.1:6379, and upload RDB file:
+Run against live Redis server, say, on address 127.0.0.1:6379, and upload RDB file:
 
-    % ./bin/rdb-cli ./test/dumps/multiple_lists_strings.rdb redis -h 127.0.0.1 -p 6379
+    % rdb-cli ./test/dumps/multiple_lists_strings.rdb redis -h 127.0.0.1 -p 6379
 
 (rdb-cli usage available [here](#rdb-cli usage).)
 

--- a/api/librdb-api.h
+++ b/api/librdb-api.h
@@ -477,10 +477,6 @@ _LIBRDB_API void RDB_handleByLevel(RdbParser *p, RdbDataType t, RdbHandlersLevel
  * Follows the semantic semver versioning convention
  *****************************************************************/
 
-#define RDB_MAJOR_VERSION 255
-#define RDB_MINOR_VERSION 255
-#define RDB_PATCH_VERSION 255
-
 _LIBRDB_API const char* RDB_getLibVersion(int* major, int* minor, int* patch);
 
 #ifdef __cplusplus

--- a/src/cli/Makefile
+++ b/src/cli/Makefile
@@ -27,7 +27,8 @@ endif
 
 ######################################### RULES #######################################
 all: $(TARGET_APP)
-	mv $(TARGET_APP) ../../bin
+	rm -f ../../bin/$(TARGET_APP)
+	cp $(TARGET_APP) ../../bin/
 	@echo "Done.";
 
 $(TARGET_APP): %: %.c

--- a/src/lib/parser.c
+++ b/src/lib/parser.c
@@ -10,6 +10,7 @@
 #include "../../deps/redis/crc64.h"
 #include "bulkAlloc.h"
 #include "parser.h"
+#include "version.h"
 #include "defines.h"
 #include "../../deps/redis/endianconv.h"
 #include "../../deps/redis/util.h"
@@ -449,16 +450,10 @@ _LIBRDB_API void RDB_handleByLevel(RdbParser *p, RdbDataType type, RdbHandlersLe
 }
 
 _LIBRDB_API const char *RDB_getLibVersion(int *major, int *minor, int *patch) {
-    static int initialized = 0;
-    static char versionString[50];
-
-    if (major) *major = RDB_MAJOR_VERSION;
-    if (minor) *minor = RDB_MINOR_VERSION;
-    if (patch) *patch = RDB_PATCH_VERSION;
-    if (!initialized) sprintf(versionString, "%d.%d.%d", *major, *minor, *patch);
-    initialized = 1;
-
-    return versionString;
+    if (major) *major = LIBRDB_MAJOR_VERSION;
+    if (minor) *minor = LIBRDB_MINOR_VERSION;
+    if (patch) *patch = LIBRDB_PATCH_VERSION;
+    return LIBRDB_VERSION_STRING;
 }
 
 /*** various functions ***/

--- a/src/lib/version.h
+++ b/src/lib/version.h
@@ -1,0 +1,8 @@
+#define LIBRDB_MAJOR_VERSION 0
+#define LIBRDB_MINOR_VERSION 0
+#define LIBRDB_PATCH_VERSION 1
+
+/* Keep direct value for external readers */
+#define LIBRDB_VERSION_STRING "0.0.1"
+
+

--- a/test/test_rdb_cli.c
+++ b/test/test_rdb_cli.c
@@ -55,7 +55,7 @@ static void test_rdb_cli_resp_common(const char *rdbfile) {
 
 static void test_rdb_cli_json(void **state) {
     UNUSED(state);
-    runSystemCmd("./bin/rdb-cli ./test/dumps/multiple_lists_strings.rdb json -w -o ./test/tmp/out.json  > /dev/null ");
+    runSystemCmd("./bin/rdb-cli ./test/dumps/multiple_lists_strings.rdb json -f -w -o ./test/tmp/out.json  > /dev/null ");
     assert_json_equal(DUMP_FOLDER("multiple_lists_strings_data.json"), "./test/tmp/out.json");
 }
 


### PR DESCRIPTION
- Be polite and avoid running tests as part of 'make all'
  This way we also can install `librdb` without cmocka and valgrind.
- Support install and uninstall and add versioning.
- Fix README accordingly.