### PR TITLE
Do not use empty function declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
   build-clang:
     runs-on: ubuntu-latest
     env:
-      CC: clang-15
+      CC: clang
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
   build-clang:
     runs-on: ubuntu-latest
     env:
-      CC: clang
+      CC: clang-15
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/examples/example1.c
+++ b/examples/example1.c
@@ -27,7 +27,7 @@ void logger(RdbLogLevel l, const char *msg) {
  * Example of RDB to Json file conversion. It also shows the usage
  * of two FilterKey.
  *******************************************************************/
-int main() {
+int main(void) {
     RdbParser *parser;
     RdbxReaderFile *reader;
     RdbxToJson *rdbToJson;

--- a/src/cli/rdb-cli.c
+++ b/src/cli/rdb-cli.c
@@ -52,7 +52,7 @@ static void loggerWrap(RdbLogLevel l, const char *msg, ...) {
     logger(l, tmp);
 }
 
-static void printUsage() {
+static void printUsage(void) {
     printf("[v%s] ", RDB_getLibVersion(NULL,NULL,NULL));
     printf("Usage: rdb-cli /path/to/dump.rdb [OPTIONS] {json|resp|redis} [FORMAT_OPTIONS]\n");
     printf("OPTIONS:\n");

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -58,7 +58,7 @@ char *readFile(const char *filename,  size_t *length) {
     return str;
 }
 
-void cleanTmpFolder() {
+void cleanTmpFolder(void) {
     const char *folder_path = "./test/tmp";
 
     DIR *dir = opendir(folder_path);
@@ -179,7 +179,7 @@ int findFreePort(int startPort, int endPort) {
     return -1;
 }
 
-void cleanupRedisServer() {
+void cleanupRedisServer(void) {
     if (redisPID)
         kill(redisPID, SIGTERM);
 }
@@ -305,7 +305,7 @@ void setupRedisServer(const char *installFolder) {
     }
 }
 
-void teardownRedisServer() {
+void teardownRedisServer(void) {
     if (redisConnContext) {
         assert_non_null(redisConnContext);
         assert_null(redisCommand(redisConnContext, "SHUTDOWN"));
@@ -315,14 +315,14 @@ void teardownRedisServer() {
     }
 }
 
-int isSetRedisServer() {
+int isSetRedisServer(void) {
     return (redisConnContext != NULL);
 }
 
 /* Redis OSS does not support restoring module auxiliary data. This feature
  * is currently available only in Redis Enterprise. There are plans to bring
  * this functionality to Redis OSS in the near future. */
-int isSupportRestoreModuleAux() {
+int isSupportRestoreModuleAux(void) {
     static int supported = -1;   /* -1=UNINIT, 0=NO, 1=YES */
     if (supported == -1) {
         char *res = sendRedisCmd("RESTOREMODAUX", REDIS_REPLY_ERROR, NULL);

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -33,21 +33,21 @@ void assert_json_equal(const char *f1, const char *f2, int ignoreListOrder);
 /* Test against Redis Server */
 extern int redisPort;
 void setupRedisServer(const char *installFolder);
-void teardownRedisServer();
-int isSetRedisServer();
+void teardownRedisServer(void);
+int isSetRedisServer(void);
 char *sendRedisCmd(char *cmd, int expRetType, char *expRsp);
-int isSupportRestoreModuleAux();
+int isSupportRestoreModuleAux(void);
 
 /* test groups */
-int group_rdb_to_redis();
-int group_test_rdb_cli();
-int group_rdb_to_resp();
-int group_main();
-int group_rdb_to_json();
-int group_mem_management();
-int group_pause();
-int group_bulk_ops();
-int group_test_resp_reader();
+int group_rdb_to_redis(void);
+int group_test_rdb_cli(void);
+int group_rdb_to_resp(void);
+int group_main(void);
+int group_rdb_to_json(void);
+int group_mem_management(void);
+int group_pause(void);
+int group_bulk_ops(void);
+int group_test_resp_reader(void);
 
 /* simulate external malloc */
 void *xmalloc(size_t size);
@@ -56,7 +56,7 @@ void xfree(void *ptr);
 void *xrealloc(void *ptr, size_t size);
 
 char *readFile(const char *filename, size_t *len);
-void cleanTmpFolder();
+void cleanTmpFolder(void);
 void setEnvVar (const char *name, const char *val);
 char *substring(char *str, size_t len, char *substr);
 void assert_file_payload(const char *filename, char *expData, int expLen, MatchType matchType, int expMatch);

--- a/test/test_rdb_to_redis.c
+++ b/test/test_rdb_to_redis.c
@@ -295,7 +295,7 @@ static void test_rdb_to_redis_del_before_write(void **state) {
 }
 
 /*************************** group_rdb_to_redis *******************************/
-int group_rdb_to_redis() {
+int group_rdb_to_redis(void) {
 
     if (!isSetRedisServer()) {
         printf("[  SKIPPED ] (Redis installation folder is not configured)\n");


### PR DESCRIPTION
New C standard won't allow empty declarations. Looks like `clang-15` already warns about that. 
This PR fixes the warnings. 