### PR TITLE
Add soname, pkgconfig and fix makefile issues

### DIFF
--- a/librdb-ext.pc.in
+++ b/librdb-ext.pc.in
@@ -1,0 +1,11 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: librdb-ext
+Description: Extension library for parsing Redis RDB to JSON and RESP protocols
+Version: @VERSION@
+Libs: -L${libdir} -lrdb-ext
+Requires: librdb
+Cflags: -I${includedir}

--- a/librdb.pc.in
+++ b/librdb.pc.in
@@ -1,0 +1,10 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: librdb
+Description: Library for parsing Redis RDB files
+Version: @VERSION@
+Libs: -L${libdir} -lrdb
+Cflags: -I${includedir}

--- a/src/ext/Makefile
+++ b/src/ext/Makefile
@@ -3,10 +3,11 @@ default: all
 LIB_NAME              = rdb
 LIB_NAME_EXT          = $(LIB_NAME)-ext
 LIB_DIR               = ../../lib
+LIBRDB_SONAME_EXT     = lib$(LIB_NAME_EXT).so.${LIBRDB_VERSION}
 
 TARGET_LIB_STATIC     = $(LIB_DIR)/lib$(LIB_NAME).a
 # Artifacts:
-TARGET_LIB_EXT        = $(LIB_DIR)/lib$(LIB_NAME_EXT).so
+TARGET_LIB_EXT        = $(LIB_DIR)/$(LIBRDB_SONAME_EXT)
 TARGET_LIB_STATIC_EXT = $(LIB_DIR)/lib$(LIB_NAME_EXT).a
 
 #########################################################################################
@@ -38,7 +39,7 @@ all: $(TARGET_LIB_EXT) $(TARGET_LIB_STATIC_EXT)
 	@echo "Done.";
 
 $(TARGET_LIB_EXT): $(OBJECTS) $(REDIS_OBJECTS)
-	$(CC) -o $@ -shared ${LDFLAGS} $^  $(LIBS)
+	$(CC) -o $@ -shared -Wl,-soname,${LIBRDB_SONAME_EXT} ${LDFLAGS} $^  $(LIBS)
 
 $(TARGET_LIB_STATIC_EXT): $(OBJECTS) $(REDIS_OBJECTS)
 	ar rcs $@ $^

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -2,9 +2,10 @@ default: all
 
 LIB_NAME              = rdb
 LIB_DIR               = ../../lib
+LIBRDB_SONAME         = lib$(LIB_NAME).so.${LIBRDB_VERSION}
 
 # Artifacts:
-TARGET_LIB            = $(LIB_DIR)/lib$(LIB_NAME).so
+TARGET_LIB            = $(LIB_DIR)/${LIBRDB_SONAME}
 TARGET_LIB_STATIC     = $(LIB_DIR)/lib$(LIB_NAME).a
 
 # Source files in the working directory
@@ -38,7 +39,7 @@ all: $(TARGET_LIB) $(TARGET_LIB_STATIC)
 	@echo "Done.";
 
 $(TARGET_LIB): $(OBJECTS) $(REDIS_OBJECTS)
-	$(CC) -o $@ -shared ${LDFLAGS} $^
+	$(CC) -o $@ -shared -Wl,-soname,${LIBRDB_SONAME} ${LDFLAGS} $^
 
 $(TARGET_LIB_STATIC): $(OBJECTS) $(REDIS_OBJECTS)
 	ar rcs $@ $^


### PR DESCRIPTION
- Renamed `VERSION` variable to `LIBRDB_VERSION`. 
  If outer makefile sets `VERSION` variable for some purpose, it overrides this one and causes a mess. 

- Added option to install static or dynamic libraries.
- Added basic pkgconfig support
- Added `soname` to the shared libraries. Some systems (e.g. redhat based ones) fetch library name from it. 