### PR TITLE
RDB2RESP: Add single-db flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ destruction, or when newer block replacing old one.
                                           as RESTORE is closely tied to specific RDB versions. If versions not
                                           aligned the parser will generate higher-level commands instead.
             -o, --output <FILE>           Specify the output file (For 'resp' only: if not specified, output to stdout)
+            -1, --single-db               Avoid SELECT command. DBs in RDB will be stored to db 0. Watchout for conflicts
             -s, --start-cmd-num <NUM>     Start writing redis from command number
             -e, --enum-commands           Command enumeration and tracing by preceding each generated RESP command
                                           with debug command of type: `SET _RDB_CLI_CMD_ID_ <CMD-ID>`

--- a/api/librdb-ext-api.h
+++ b/api/librdb-ext-api.h
@@ -132,6 +132,17 @@ typedef struct RdbxToRespConf {
      * this functionality to Redis OSS in the near future. */
      int supportRestoreModuleAux;
 
+    /* Single DB mode. i.e., avoid using the SELECT command. In turn all keys and
+     * data in the RDB will be stored in the default DB (index 0).
+     *
+     * This approach can be helpful when dealing with scenarios such as data
+     * partitioned into multiple DBs where you need to merge them into a single DB.
+     * Be cautious of potential key conflicts in such cases.
+     *
+     * Additionally, this can be useful when migrating data to Redis Enterprise,
+     * which does not support multiple DBs and command SELECT should be avoided. */
+     int singleDb;
+
 } RdbxToRespConf;
 
 _LIBRDB_API RdbxToResp *RDBX_createHandlersToResp(RdbParser *, RdbxToRespConf *);

--- a/api/librdb-ext-api.h
+++ b/api/librdb-ext-api.h
@@ -137,10 +137,7 @@ typedef struct RdbxToRespConf {
      *
      * This approach can be helpful when dealing with scenarios such as data
      * partitioned into multiple DBs where you need to merge them into a single DB.
-     * Be cautious of potential key conflicts in such cases.
-     *
-     * Additionally, this can be useful when migrating data to Redis Enterprise,
-     * which does not support multiple DBs and command SELECT should be avoided. */
+     * Be cautious of potential key conflicts in such case. */
      int singleDb;
 
 } RdbxToRespConf;

--- a/src/cli/Makefile
+++ b/src/cli/Makefile
@@ -32,10 +32,12 @@ all: $(TARGET_APP)
 	cp $(TARGET_APP) ../../bin/
 	@echo "Done.";
 
-$(TARGET_APP): %: %.c
+$(TARGET_APP): %: %.c  lib_dependency
 	$(CC) $(CFLAGS) -o $@ $<  $(DEBUG) $(LIBS)
+
+lib_dependency: $(LIB_DIR)/$(LIB_NAME_EXT)
 
 clean:
 	@rm -rvf $(TARGETS) ./*.o ../../bin/$(TARGET_APP)
 
-.PHONY: all clean
+.PHONY: all clean lib_dependency

--- a/src/cli/rdb-cli.c
+++ b/src/cli/rdb-cli.c
@@ -117,6 +117,7 @@ static void printUsage(int shortUsage) {
     printf("\t                              as RESTORE is closely tied to specific RDB versions. If versions not\n");
     printf("\t                              aligned the parser will generate higher-level commands instead.\n");
     printf("\t-o, --output <FILE>           Specify the output file (For 'resp' only: if not specified, output to stdout)\n");
+    printf("\t-1, --single-db               Avoid SELECT command. DBs in RDB will be stored to db 0. Watchout for conflicts\n");
     printf("\t-s, --start-cmd-num <NUM>     Start writing redis from command number\n");
     printf("\t-e, --enum-commands           Command enumeration and tracing by preceding each generated RESP command\n");
     printf("\t                              with debug command of type: `SET _RDB_CLI_CMD_ID_ <CMD-ID>`\n");
@@ -179,6 +180,7 @@ static RdbRes formatRedis(RdbParser *parser, int argc, char **argv) {
         if (getOptArgVal(argc, argv, &at, "-p", "--port", NULL, &port, 1, 65535)) continue;
         if (getOptArg(argc, argv, &at, "-r", "--support-restore", &(conf.supportRestore), NULL)) continue;
         if (getOptArg(argc, argv, &at, "-d", "--del-before-write", &(conf.delKeyBeforeWrite), NULL)) continue;
+        if (getOptArg(argc, argv, &at, "-1", "--single-db", &(conf.singleDb), NULL)) continue;
         if (getOptArg(argc, argv, &at, "-t", "--target-redis-ver", NULL, &(conf.dstRedisVersion))) continue;
         if (getOptArgVal(argc, argv, &at, "-l", "--pipeline-depth", NULL, &pipeDepthVal, 1, 1000)) continue;
         if (getOptArgVal(argc, argv, &at, "-n", "--start-cmd-num", NULL, &startCmdNum, 1, INT_MAX)) continue;
@@ -252,6 +254,7 @@ static RdbRes formatResp(RdbParser *parser, int argc, char **argv) {
         if (getOptArg(argc, argv, &at, "-o", "--output", NULL, &output)) continue;
         if (getOptArg(argc, argv, &at, "-r", "--support-restore", &(conf.supportRestore), NULL)) continue;
         if (getOptArg(argc, argv, &at, "-d", "--del-before-write", &(conf.delKeyBeforeWrite), NULL)) continue;
+        if (getOptArg(argc, argv, &at, "-1", "--single-db", &(conf.singleDb), NULL)) continue;
         if (getOptArg(argc, argv, &at, "-t", "--target-redis-ver", NULL, &(conf.dstRedisVersion))) continue;
         if (getOptArg(argc, argv, &at, "-e", "--enum-commands", &commandEnum, NULL)) continue;
         if (getOptArgVal(argc, argv, &at, "-n", "--start-cmd-num", NULL, &startCmdNum, 1, INT_MAX)) continue;

--- a/src/ext/handlersToResp.c
+++ b/src/ext/handlersToResp.c
@@ -342,6 +342,11 @@ static RdbRes toRespNewDb(RdbParser *p, void *userData, int dbid) {
     char dbidStr[10], cntStr[10];
 
     RdbxToResp *ctx = userData;
+
+    /* If configured singleDb then skip writing SELECT */
+    if (ctx->conf.singleDb)
+        return RDB_OK;
+
     int cnt = ll2string(dbidStr, sizeof(dbidStr), dbid);
 
     RdbxRespWriterStartCmd startCmd;

--- a/src/lib/parser.c
+++ b/src/lib/parser.c
@@ -1402,6 +1402,7 @@ RdbStatus elementNextRdbType(RdbParser *p) {
     /*** ENTER SAFE STATE ***/
 
     p->currOpcode = *((unsigned char *)biType->ref);
+
     switch (p->currOpcode) {
         case RDB_OPCODE_EXPIRETIME:         return nextParsingElement(p, PE_EXPIRETIME);
         case RDB_OPCODE_EXPIRETIME_MS:      return nextParsingElement(p, PE_EXPIRETIMEMSEC);

--- a/test/test_rdb_to_resp.c
+++ b/test/test_rdb_to_resp.c
@@ -284,12 +284,12 @@ static void test_r2r_module_aux(void **state) {
 static void test_r2r_stream_with_target_62_and_72(void **state) {
     size_t fileLen;
     UNUSED(state);
-    RdbxToRespConf r2rConf1 = { .delKeyBeforeWrite=0, .supportRestore=0, .dstRedisVersion="6.2",};
+    RdbxToRespConf r2rConf1 = { .delKeyBeforeWrite=0, .supportRestore=0, .dstRedisVersion="6.2", .singleDb=0};
     char *f1 = readFile(DUMP_FOLDER("stream_v11_target_ver_6.2.resp"), &fileLen, NULL);
     testRdbToRespCommon("stream_v11.rdb", &r2rConf1, f1, fileLen, M_ENTIRE, 1);
     free(f1);
 
-    RdbxToRespConf r2rConf = { .delKeyBeforeWrite=0, .supportRestore=0, .dstRedisVersion="7.2",};
+    RdbxToRespConf r2rConf = { .delKeyBeforeWrite=0, .supportRestore=0, .dstRedisVersion="7.2", .singleDb=0};
     f1 = readFile(DUMP_FOLDER("stream_v11_target_ver_7.2.resp"), &fileLen, NULL);
     testRdbToRespCommon("stream_v11.rdb", &r2rConf, f1, fileLen, M_ENTIRE, 1);
     free(f1);


### PR DESCRIPTION
On RDB2RESP, add `singleDb` flag. i.e., avoid using the SELECT command. 
In turn all keys and data in the RDB will be stored in the default DB (index 0).
This approach can be helpful when dealing with scenarios such as data partitioned 
into multiple DBs where you need to merge them into a single DB. Be cautious of 
potential key conflicts in such cases. 

Add also makefile dependency for CLI to rebuild on each static librdb modification.

