### PR TITLE
Fix module-Aux handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,15 +117,11 @@ into corresponding callbacks.
 If we only care about DB logical data-types, for example in order to export data to
 another framework, then we better register our callbacks at level2.
 
-Note, the set of handlers at Level1 get the data further parsed than the one "below it" at
-Level0. The same goes between Level2 and Level1 correspondingly.
-
 ### Handlers
-The **Handlers** represent a set of builtin or user-defined functions that will be called on the
-parsed data. Future plan to support built-in Handlers:
-* Convert RDB to JSON file handlers.
-* Convert RDB to RESP protocol handlers.
-* Memory Analyze (TODO)
+The **Handlers** represent a set of builtin or user-defined functions that will 
+be called on the parsed data. Currently, librdb supports 2 built-in Handlers that 
+converts to JSON and RESSP and one extension to RESP handlers that in addition 
+can play it against live server.
 
 It is possible to attach to parser more than one set of handlers at the same level.
 That is, for a given data at a given level, the parser will call each of the handlers that
@@ -134,8 +130,8 @@ is the most time-consuming task of the parser, and it can save time by making a 
 parse yet invoke multiple sets of handlers.
 
 More common reason is that a handlers can be used also as a Filter to decide whether to
-propagate data to the next set of handlers in-line (Such built-in filters can be
-found at extension library of this project). Note that for any given level, order of
+propagate data to the next set of handlers in-line. Such built-in filters can be
+found at extension library of this project. Note that for any given level, order of
 calls to handlers will be the opposite to order of their registration to that level.
 
 Furthermore, it is also possible to attach multiple handlers at different levels, which is

--- a/src/ext/handlersToResp.c
+++ b/src/ext/handlersToResp.c
@@ -955,6 +955,13 @@ static RdbRes toRespRestoreFragEnd(RdbParser *p, void *userData) {
 
     int len = 10;
 
+    /* if processing module-aux then we are done (no ABSTTL, IDLETIME or FREQ) */
+    if (ctx->restoreCtx.isModuleAux) {
+        len += snprintf(cmd+len, sizeof(cmd)-len, "\r\n");
+        struct iovec iov = {cmd, len};
+        return writevWrap(ctx, &iov, 1, NULL, 1);
+    }
+
     /* Add REPLACE if needed */
     if (ctx->keyCtx.delBeforeWrite == DEL_KEY_BEFORE_BY_RESTORE_REPLACE)
         len += snprintf(cmd+len, sizeof(cmd)-len, "\r\n$7\r\nREPLACE\r\n");

--- a/src/ext/handlersToResp.c
+++ b/src/ext/handlersToResp.c
@@ -955,7 +955,7 @@ static RdbRes toRespRestoreFragEnd(RdbParser *p, void *userData) {
 
     int len = 10;
 
-    /* if processing module-aux then we are done (no ABSTTL, IDLETIME or FREQ) */
+    /* if processing module-aux then we are done (no REPLACE, ABSTTL, IDLETIME or FREQ) */
     if (ctx->restoreCtx.isModuleAux) {
         len += snprintf(cmd+len, sizeof(cmd)-len, "\r\n");
         struct iovec iov = {cmd, len};

--- a/src/lib/parser.h
+++ b/src/lib/parser.h
@@ -322,8 +322,8 @@ typedef struct RawContext {
      * this issue, the parser gathers all payload data for these types and only
      * provides it to callback handlers once it reaches the end of the type and
      * knows its total size. However, for types like strings, whose sizes are
-     * already known at the beginning, the parser will not aggregate the entire
-     * payload if it is large enough, but stream it to handleFrag callback. */
+     * already known at the beginning, the parser will only partially aggregate
+     * the payload, if it is large enough, and stream it to handleFrag callback. */
     enum {
         AGG_TYPE_UNINIT,
         AGG_TYPE_ENTIRE_DATA,

--- a/src/lib/parserRaw.c
+++ b/src/lib/parserRaw.c
@@ -678,7 +678,7 @@ RdbStatus elementRawModule(RdbParser *p) {
                     updateElementState(p, ST_NEXT_OPCODE, 0);
                     break;
                 } else {
-                    assert(p->currOpcode == RDB_TYPE_MODULE_AUX);
+                    assert(p->currOpcode == RDB_OPCODE_MODULE_AUX);
 
                     /* Init Aggregator of bulks here since no new-key precedes module aux */
                     aggReset(p);

--- a/src/lib/parserRaw.c
+++ b/src/lib/parserRaw.c
@@ -677,13 +677,14 @@ RdbStatus elementRawModule(RdbParser *p) {
                     IF_NOT_OK_RETURN(aggUpdateWritten(p, len));
                     updateElementState(p, ST_NEXT_OPCODE, 0);
                     break;
+                } else {
+                    assert(p->currOpcode == RDB_TYPE_MODULE_AUX);
+
+                    /* Init Aggregator of bulks here since no new-key precedes module aux */
+                    aggReset(p);
+                    updateElementState(p, ST_AUX_START, 0);
                 }
-
-                /* No new-key precedes module aux. Init Aggregator of bulks here. */
-                aggReset(p);
-
-                updateElementState(p, ST_AUX_START, 0);
-            } /* fall-thru */
+            } /* fall-thru - only for of RDB_TYPE_MODULE_AUX */
 
             case ST_AUX_START: {
                 int len = 0;


### PR DESCRIPTION
- parserRaw.c didn't init appropriately aggregation of bulks for module-aux. Refactor and call to `aggReset()`.
- module-aux could wrongly include REPLACE, ABSTTL, IDLETIME or FREQ flags.