### PR TITLE
RDB2RESP: Fix functions registration

### DIFF
--- a/api/librdb-ext-api.h
+++ b/api/librdb-ext-api.h
@@ -113,6 +113,12 @@ typedef struct RdbxToRespConf {
      * RESTORE command. */
     int delKeyBeforeWrite;
 
+    /* funcLibReplaceIfExist - If function-library with the same name is already
+     * exist in the target redis, then replace it rather than return failure.
+     * (Implemented in RESP by adding `REPLACE` flag to the `FUNCTION LOAD`
+     * command) */
+    int funcLibReplaceIfExist;
+
     /* If supportRestore, then data-types will be translated to RESTORE with
      * raw data instead of data-types commands. This is a performance optimization
      * that requires to be version aligned. */

--- a/src/cli/rdb-cli.c
+++ b/src/cli/rdb-cli.c
@@ -112,6 +112,7 @@ static void printUsage(int shortUsage) {
     printf("FORMAT_OPTIONS ('redis'|'resp'):\n");
     printf("\t-r, --support-restore         Use the RESTORE command when possible\n");
     printf("\t-d, --del-before-write        Delete each key before writing. Relevant for non-empty db\n");
+    printf("\t-f, --func-replace-if-exist   Replace function-library if already exists in the same name rather than aborting\n");
     printf("\t-t, --target-redis-ver <VER>  Specify the target Redis version. Helps determine which commands can\n");
     printf("\t                              be applied. Particularly crucial if support-restore being used \n");
     printf("\t                              as RESTORE is closely tied to specific RDB versions. If versions not\n");
@@ -180,6 +181,7 @@ static RdbRes formatRedis(RdbParser *parser, int argc, char **argv) {
         if (getOptArgVal(argc, argv, &at, "-p", "--port", NULL, &port, 1, 65535)) continue;
         if (getOptArg(argc, argv, &at, "-r", "--support-restore", &(conf.supportRestore), NULL)) continue;
         if (getOptArg(argc, argv, &at, "-d", "--del-before-write", &(conf.delKeyBeforeWrite), NULL)) continue;
+        if (getOptArg(argc, argv, &at, "-f", "--func-replace-if-exist", &(conf.funcLibReplaceIfExist), NULL)) continue;
         if (getOptArg(argc, argv, &at, "-1", "--single-db", &(conf.singleDb), NULL)) continue;
         if (getOptArg(argc, argv, &at, "-t", "--target-redis-ver", NULL, &(conf.dstRedisVersion))) continue;
         if (getOptArgVal(argc, argv, &at, "-l", "--pipeline-depth", NULL, &pipeDepthVal, 1, 1000)) continue;
@@ -254,6 +256,7 @@ static RdbRes formatResp(RdbParser *parser, int argc, char **argv) {
         if (getOptArg(argc, argv, &at, "-o", "--output", NULL, &output)) continue;
         if (getOptArg(argc, argv, &at, "-r", "--support-restore", &(conf.supportRestore), NULL)) continue;
         if (getOptArg(argc, argv, &at, "-d", "--del-before-write", &(conf.delKeyBeforeWrite), NULL)) continue;
+        if (getOptArg(argc, argv, &at, "-f", "--func-replace-if-exist", &(conf.funcLibReplaceIfExist), NULL)) continue;
         if (getOptArg(argc, argv, &at, "-1", "--single-db", &(conf.singleDb), NULL)) continue;
         if (getOptArg(argc, argv, &at, "-t", "--target-redis-ver", NULL, &(conf.dstRedisVersion))) continue;
         if (getOptArg(argc, argv, &at, "-e", "--enum-commands", &commandEnum, NULL)) continue;

--- a/src/ext/handlersToResp.c
+++ b/src/ext/handlersToResp.c
@@ -204,6 +204,9 @@ static RdbRes resolveSupportRestore(RdbParser *p, RdbxToResp *ctx) {
     /* Enforce RESTORE for modules. librdb cannot really parse high-level module object */
     RDB_handleByLevel(p, RDB_DATA_TYPE_MODULE, RDB_LEVEL_RAW);
 
+    /* Avoid RESTORE for functions. Redis doesn't have API to RESTORE functions */
+    RDB_handleByLevel(p, RDB_DATA_TYPE_FUNCTION, RDB_LEVEL_DATA);
+
     return RDB_OK;
 }
 

--- a/src/lib/parser.c
+++ b/src/lib/parser.c
@@ -735,6 +735,9 @@ static void chainHandlersAcrossLevels(RdbParser *p) {
 }
 
 static void resolveMultipleLevelsRegistration(RdbParser *p) {
+    RDB_log(p, RDB_LOG_INF, "Number sets of handlers registered at level RAW/STRUCT/DATA: %d/%d/%d",
+            p->numHandlers[RDB_LEVEL_RAW], p->numHandlers[RDB_LEVEL_STRUCT], p->numHandlers[RDB_LEVEL_DATA]);
+
     /* find the lowest level that handlers are registered */
     int lvl = (p->numHandlers[RDB_LEVEL_RAW]) ? RDB_LEVEL_RAW :
               (p->numHandlers[RDB_LEVEL_STRUCT]) ? RDB_LEVEL_STRUCT :

--- a/test/test_rdb_to_redis.c
+++ b/test/test_rdb_to_redis.c
@@ -371,7 +371,7 @@ static void test_rdb_to_redis_func_lib_replace_if_exist(void **state) {
                                                   getRedisPort()));
 
         while ((status = RDB_parse(parser)) == RDB_STATUS_WAIT_MORE_DATA);
-        RDB_deleteParser(parser);
+
 
         /* Verify myfunc is loaded (either succeeded or not) */
         sendRedisCmd("FUNCTION LIST", REDIS_REPLY_ARRAY, "myfunc");
@@ -384,6 +384,7 @@ static void test_rdb_to_redis_func_lib_replace_if_exist(void **state) {
             assert_int_equal(err, RDBX_ERR_RESP_WRITE);
             assert_non_null(strstr(RDB_getErrorMessage(parser), "mylib"));
         }
+        RDB_deleteParser(parser);
     }
 }
 

--- a/test/test_rdb_to_resp.c
+++ b/test/test_rdb_to_resp.c
@@ -284,12 +284,12 @@ static void test_r2r_module_aux(void **state) {
 static void test_r2r_stream_with_target_62_and_72(void **state) {
     size_t fileLen;
     UNUSED(state);
-    RdbxToRespConf r2rConf1 = { .delKeyBeforeWrite=0, .supportRestore=0, .dstRedisVersion="6.2", .singleDb=0};
+    RdbxToRespConf r2rConf1 = { .dstRedisVersion="6.2"};
     char *f1 = readFile(DUMP_FOLDER("stream_v11_target_ver_6.2.resp"), &fileLen, NULL);
     testRdbToRespCommon("stream_v11.rdb", &r2rConf1, f1, fileLen, M_ENTIRE, 1);
     free(f1);
 
-    RdbxToRespConf r2rConf = { .delKeyBeforeWrite=0, .supportRestore=0, .dstRedisVersion="7.2", .singleDb=0};
+    RdbxToRespConf r2rConf = { .dstRedisVersion="7.2" };
     f1 = readFile(DUMP_FOLDER("stream_v11_target_ver_7.2.resp"), &fileLen, NULL);
     testRdbToRespCommon("stream_v11.rdb", &r2rConf, f1, fileLen, M_ENTIRE, 1);
     free(f1);


### PR DESCRIPTION
In case of multiple levels registration of callbacks, RDB2RESP need to take
care to enforce that functions will be handled only by data-level (To simplify
implementation we avoid using FUNCTION RESTORE command and Instead, 
always use FUNCTION LOAD command. It is expected that there won't be 
many functions in the RDB file in which requires optimization).