### PR TITLE
Fix FD partial read

### DIFF
--- a/src/ext/readerFileDesc.c
+++ b/src/ext/readerFileDesc.c
@@ -32,7 +32,7 @@ static RdbStatus readFileDesc(void *data, void *buf, size_t len) {
         /* read some data */
         if (likely(bytesRead > 0)) {
             totalBytesRead += bytesRead;
-            break;
+            continue;
         }
 
         /* didn't read any data. Stop. */


### PR DESCRIPTION
In case readFileDesc() read less than requested then required to continue to another iteration rather break.