### PR TITLE
rdb-cli - Close log file also on error

### DIFF
--- a/src/cli/rdb-cli.c
+++ b/src/cli/rdb-cli.c
@@ -360,6 +360,11 @@ int readCommonOptions(RdbParser *p, int argc, char* argv[], Options *options, in
     return at;
 }
 
+void closeLogFileOnExit() {
+    if (logfile != NULL)
+        fclose(logfile);
+}
+
 int main(int argc, char **argv)
 {
     Options options;
@@ -391,6 +396,8 @@ int main(int argc, char **argv)
         return RDB_ERR_GENERAL;
     }
 
+    atexit(closeLogFileOnExit);
+
     /* create the parser and attach it a file reader */
     RdbParser *parser = RDB_createParserRdb(NULL);
     RDB_setLogLevel(parser, RDB_LOG_INF);
@@ -419,8 +426,6 @@ int main(int argc, char **argv)
         return RDB_getErrorCode(parser);
 
     RDB_deleteParser(parser);
-
-    fclose(logfile);
 
     return 0;
 }


### PR DESCRIPTION
Added `atexit(closeLogFileOnExit);`