### PR TITLE
Add support to hash-field-expiration RDB_TYPE v2

### DIFF
--- a/src/ext/handlersFilter.c
+++ b/src/ext/handlersFilter.c
@@ -43,10 +43,12 @@ static void initOpcodeToType(RdbxFilter *ctx) {
     ctx->opToType[RDB_TYPE_ZSET_LISTPACK] = RDB_DATA_TYPE_ZSET;
     /*hash*/
     ctx->opToType[RDB_TYPE_HASH] = RDB_DATA_TYPE_HASH;
+    ctx->opToType[RDB_TYPE_HASH_METADATA_PRE_GA] = RDB_DATA_TYPE_HASH;
     ctx->opToType[RDB_TYPE_HASH_METADATA] = RDB_DATA_TYPE_HASH;
     ctx->opToType[RDB_TYPE_HASH_ZIPMAP] = RDB_DATA_TYPE_HASH;
     ctx->opToType[RDB_TYPE_HASH_ZIPLIST] = RDB_DATA_TYPE_HASH;
     ctx->opToType[RDB_TYPE_HASH_LISTPACK] = RDB_DATA_TYPE_HASH;
+    ctx->opToType[RDB_TYPE_HASH_LISTPACK_EX_PRE_GA] = RDB_DATA_TYPE_HASH;
     ctx->opToType[RDB_TYPE_HASH_LISTPACK_EX] = RDB_DATA_TYPE_HASH;
     /*module*/
     ctx->opToType[RDB_TYPE_MODULE_2] = RDB_DATA_TYPE_MODULE;

--- a/src/lib/defines.h
+++ b/src/lib/defines.h
@@ -16,7 +16,6 @@
 #define RDB_TYPE_MODULE_PRE_GA 6 /* Used in 4.0 release candidates */
 #define RDB_TYPE_MODULE_2 7 /* Module value with annotations for parsing without
                                the generating module being loaded. */
-/* NOTE: WHEN ADDING NEW RDB TYPE, UPDATE rdbIsObjectType() BELOW */
 
 /* Object types for encoded objects. */
 #define RDB_TYPE_HASH_ZIPMAP        9
@@ -32,10 +31,12 @@
 #define RDB_TYPE_STREAM_LISTPACKS_2 19
 #define RDB_TYPE_SET_LISTPACK       20
 #define RDB_TYPE_STREAM_LISTPACKS_3 21
-#define RDB_TYPE_HASH_METADATA      22
-#define RDB_TYPE_HASH_LISTPACK_EX   23
-#define RDB_TYPE_MAX                24
-/* NOTE: WHEN ADDING NEW RDB TYPE, UPDATE rdbIsObjectType() BELOW */
+#define RDB_TYPE_HASH_METADATA_PRE_GA 22      /* Hash with HFEs. Doesn't attach min TTL at start (7.4 RC) */
+#define RDB_TYPE_HASH_LISTPACK_EX_PRE_GA 23   /* Hash LP with HFEs. Doesn't attach min TTL at start (7.4 RC) */
+#define RDB_TYPE_HASH_METADATA      24        /* Hash with HFEs. Attach min TTL at start */
+#define RDB_TYPE_HASH_LISTPACK_EX   25        /* Hash LP with HFEs. Attach min TTL at start */
+#define RDB_TYPE_MAX                26
+
 
 /* Special RDB opcodes (saved/loaded with rdbSaveType/rdbLoadType). */
 #define RDB_OPCODE_SLOT_INFO  244   /* Individual slot info, such as slot id and size (cluster mode only). */

--- a/src/lib/parser.c
+++ b/src/lib/parser.c
@@ -12,7 +12,7 @@
  * in the README.md file as an introduction to this file implementation.
  */
 
-#include <endian.h>
+#include <inttypes.h>
 #include <assert.h>
 #include <stdarg.h>
 #include <string.h>
@@ -1698,7 +1698,7 @@ RdbStatus elementHash(RdbParser *p) {
         case ST_HASH_HEADER:
             if (p->currOpcode == RDB_TYPE_HASH_METADATA) {
                 /* digest min HFE expiration time. No need to pass it to handlers
-                   each field goanna report its expiration time anyway */
+                   as each field will report its own expiration time anyway */
                 BulkInfo *binfoExpire;
                 IF_NOT_OK_RETURN(rdbLoad(p, 8, RQ_ALLOC, NULL, &binfoExpire));
             }
@@ -1770,7 +1770,7 @@ RdbStatus elementHashLPEx(RdbParser *p) {
 
     if (p->currOpcode != RDB_TYPE_HASH_LISTPACK_EX_PRE_GA) {
         /* digest min HFE expiration time. No need to pass it to handlers
-           each field goanna report its expiration time anyway */
+           as each field will report its own expiration time anyway */
         BulkInfo *binfoExpire;
         IF_NOT_OK_RETURN(rdbLoad(p, 8, RQ_ALLOC, NULL, &binfoExpire));
     }
@@ -2666,8 +2666,8 @@ RdbStatus rdbLoadString(RdbParser *p, AllocTypeRq type, char *refBuf, BulkInfo *
                 return rdbLoadLzfString(p, type, refBuf, binfo);
             default:
                 RDB_reportError(p, RDB_ERR_STRING_UNKNOWN_ENCODING_TYPE,
-                                "rdbLoadString(): Unknown RDB string encoding type: %lu (0x%lx)",
-                                len, len);
+                                "rdbLoadString(): Unknown RDB string encoding type: %"
+                                PRIu64 " (0x%" PRIx64 ")", len, len);
                 return RDB_STATUS_ERROR;
         }
     }

--- a/src/lib/parser.c
+++ b/src/lib/parser.c
@@ -561,10 +561,12 @@ _LIBRDB_API int RDB_handleByLevel(RdbParser *p, RdbDataType type, RdbHandlersLev
             break;
         case RDB_DATA_TYPE_HASH:
             p->handleTypeObjByLevel[RDB_TYPE_HASH] = lvl;
+            p->handleTypeObjByLevel[RDB_TYPE_HASH_METADATA_PRE_GA] = lvl;
             p->handleTypeObjByLevel[RDB_TYPE_HASH_METADATA] = lvl;
             p->handleTypeObjByLevel[RDB_TYPE_HASH_ZIPMAP] = lvl;
             p->handleTypeObjByLevel[RDB_TYPE_HASH_ZIPLIST] = lvl;
             p->handleTypeObjByLevel[RDB_TYPE_HASH_LISTPACK] = lvl;
+            p->handleTypeObjByLevel[RDB_TYPE_HASH_LISTPACK_EX_PRE_GA] = lvl;
             p->handleTypeObjByLevel[RDB_TYPE_HASH_LISTPACK_EX] = lvl;
             break;
         case RDB_DATA_TYPE_MODULE:
@@ -1467,9 +1469,11 @@ RdbStatus elementNextRdbType(RdbParser *p) {
         case RDB_TYPE_LIST_ZIPLIST:         return nextParsingElementKeyValue(p, PE_RAW_LIST_ZL, PE_LIST_ZL);
         /* hash */
         case RDB_TYPE_HASH:                 return nextParsingElementKeyValue(p, PE_RAW_HASH, PE_HASH);
+        case RDB_TYPE_HASH_METADATA_PRE_GA: return nextParsingElementKeyValue(p, PE_RAW_HASH_META, PE_HASH_META);
         case RDB_TYPE_HASH_METADATA:        return nextParsingElementKeyValue(p, PE_RAW_HASH_META, PE_HASH_META);
         case RDB_TYPE_HASH_ZIPLIST:         return nextParsingElementKeyValue(p, PE_RAW_HASH_ZL, PE_HASH_ZL);
         case RDB_TYPE_HASH_LISTPACK:        return nextParsingElementKeyValue(p, PE_RAW_HASH_LP, PE_HASH_LP);
+        case RDB_TYPE_HASH_LISTPACK_EX_PRE_GA:     return nextParsingElementKeyValue(p, PE_RAW_HASH_LP_EX, PE_HASH_LP_EX);
         case RDB_TYPE_HASH_LISTPACK_EX:     return nextParsingElementKeyValue(p, PE_RAW_HASH_LP_EX, PE_HASH_LP_EX);
         case RDB_TYPE_HASH_ZIPMAP:          return nextParsingElementKeyValue(p, PE_RAW_HASH_ZM, PE_HASH_ZM);
         /* set */
@@ -1692,6 +1696,13 @@ RdbStatus elementHash(RdbParser *p) {
 
     switch (ctx->state) {
         case ST_HASH_HEADER:
+            if (p->currOpcode == RDB_TYPE_HASH_METADATA) {
+                /* digest min HFE expiration time. No need to pass it to handlers
+                   each field goanna report its expiration time anyway */
+                BulkInfo *binfoExpire;
+                IF_NOT_OK_RETURN(rdbLoad(p, 8, RQ_ALLOC, NULL, &binfoExpire));
+            }
+
             IF_NOT_OK_RETURN(rdbLoadLen(p, NULL, &(ctx->hash.numFields), NULL, NULL));
 
             ctx->key.numItemsHint = ctx->hash.numFields;
@@ -1756,6 +1767,13 @@ RdbStatus elementHashZL(RdbParser *p) {
 
 RdbStatus elementHashLPEx(RdbParser *p) {
     BulkInfo *listpackBulk;
+
+    if (p->currOpcode != RDB_TYPE_HASH_LISTPACK_EX_PRE_GA) {
+        /* digest min HFE expiration time. No need to pass it to handlers
+           each field goanna report its expiration time anyway */
+        BulkInfo *binfoExpire;
+        IF_NOT_OK_RETURN(rdbLoad(p, 8, RQ_ALLOC, NULL, &binfoExpire));
+    }
 
     IF_NOT_OK_RETURN(rdbLoadString(p, RQ_ALLOC_APP_BULK, NULL, &listpackBulk));
 
@@ -2648,7 +2666,8 @@ RdbStatus rdbLoadString(RdbParser *p, AllocTypeRq type, char *refBuf, BulkInfo *
                 return rdbLoadLzfString(p, type, refBuf, binfo);
             default:
                 RDB_reportError(p, RDB_ERR_STRING_UNKNOWN_ENCODING_TYPE,
-                                "rdbLoadString(): Unknown RDB string encoding type: %lu",len);
+                                "rdbLoadString(): Unknown RDB string encoding type: %lu (0x%lx)",
+                                len, len);
                 return RDB_STATUS_ERROR;
         }
     }

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -267,7 +267,7 @@ size_t serializeRedisReply(const redisReply *reply, char *buffer, size_t bsize) 
  *
  * Return the response serialized
  */
-char *sendRedisCmd(char *cmd, int expRetType, char *expRsp) {
+char *sendRedisCmd(const char *cmd, int expRetType, char *expRsp) {
     static char rspbuf[1024];
 
     assert_int_not_equal(currRedisInst, -1);

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -50,7 +50,7 @@ const char *getTargetRedisVersion(int *major, int *minor); /* call only after se
 void teardownRedisServer(void);
 void cleanup_json_sign_service(void);
 int isSetRedisServer(void);
-char *sendRedisCmd(char *cmd, int expRetType, char *expRsp);
+char *sendRedisCmd(const char *cmd, int expRetType, char *expRsp);
 int isSupportRestoreModuleAux(void);
 
 /* test groups */

--- a/test/test_rdb_to_redis.c
+++ b/test/test_rdb_to_redis.c
@@ -205,8 +205,8 @@ static void test_rdb_to_redis_hash_with_expire(void **state) {
         sendRedisCmd("HSET myhash f4 v1 f5 v2 f6 v3", REDIS_REPLY_INTEGER, "3");
         sendRedisCmd("HPEXPIREAT myhash 70368744177663 FIELDS 2 f4 f5",
                      REDIS_REPLY_ARRAY, "1 1");  /*time=0x3fffffffffff*/
-        rdb_save_librdb_reload_eq(0 /*restore*/, TMP_FOLDER("expire.rdb"));  /// <<<< ----- problem here
-        //rdb_save_librdb_reload_eq(1 /*restore*/, TMP_FOLDER("expire.rdb"));
+        rdb_save_librdb_reload_eq(0 /*restore*/, TMP_FOLDER("expire.rdb"));
+        rdb_save_librdb_reload_eq(1 /*restore*/, TMP_FOLDER("expire.rdb"));
         sendRedisCmd("HPEXPIRETIME myhash FIELDS 3 f4 f5 f6", REDIS_REPLY_ARRAY,
                      "70368744177663 70368744177663 -1"); /* verify expected output */
     }


### PR DESCRIPTION
The RDB serialization of hashes with expiration on fields (aka. HFE) was modified
to write also at the begining the minimum expiration time.

Following this change, the new value will be digested but won't be propagated to 
the callback handlers since it is actually a redundant information since each field 
already "reports" its expiration time to handlers (This value will might be 
used in the future for optimization in the context of dumping directly 
from RDB to FLUSH without parsing the object).

    Before:
    #define RDB_TYPE_HASH_METADATA 22
    #define RDB_TYPE_HASH_LISTPACK_EX 23
    
    After:
    /* Hash with HFEs. Doesn't attach min TTL at start */
    #define RDB_TYPE_HASH_METADATA_PRE_GA 22      
    /* Hash LP with HFEs. Doesn't attach min TTL at start */
    #define RDB_TYPE_HASH_LISTPACK_EX_PRE_GA 23   
    /* Hash with HFEs. Attach min TTL at start */
    #define RDB_TYPE_HASH_METADATA 24             
    /* Hash LP with HFEs. Attach min TTL at start */
    #define RDB_TYPE_HASH_LISTPACK_EX 25          


* Tested manually "_PRE_GA" by running tests against earlier Redis version.
