### PR TITLE
Add new handlersToPrint + expiration filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,17 +196,23 @@ destruction, or when newer block replacing old one.
 
 ### rdb-cli usage
 
-    Usage: rdb-cli /path/to/dump.rdb [OPTIONS] {json|resp|redis} [FORMAT_OPTIONS]
+    Usage: rdb-cli /path/to/dump.rdb [OPTIONS] {print|json|resp|redis} [FORMAT_OPTIONS]
     OPTIONS:
             -l, --log-file <PATH>         Path to the log file or stdout (Default: './rdb-cli.log')
-    
-            Multiple filters combination of keys/types/dbs can be specified:
             -k, --key <REGEX>             Include only keys that match REGEX
             -K  --no-key <REGEX>          Exclude all keys that match REGEX
             -t, --type <TYPE>             Include only selected TYPE {str|list|set|zset|hash|module|func}
             -T, --no-type <TYPE>          Exclude TYPE {str|list|set|zset|hash|module|func}
             -d, --dbnum <DBNUM>           Include only selected db number
             -D, --no-dbnum <DBNUM>        Exclude DB number
+            -e, --expired                 Include only expired keys
+            -E, --no-expired              Exclude expired keys
+
+    FORMAT_OPTIONS ('print'):
+            -a, --aux-val <FMT>           %f=Auxiliary-Field, %v=Auxiliary-Value (Default: "")
+            -k, --key <FMT>               %d=Db %k=Key %v=Value %t=Type %e=Expiry %r=LRU %f=LFU %i=Items
+                                          (Default: "%d,%k,%v,%t,%e,%i")
+            -o, --output <FILE>           Specify the output file. If not specified, output to stdout
     
     FORMAT_OPTIONS ('json'):
             -i, --include <EXTRAS>        To include: {aux-val|func|stream-meta}

--- a/api/librdb-api.h
+++ b/api/librdb-api.h
@@ -149,6 +149,7 @@ typedef struct RdbKeyInfo {
     long long lruIdle;      /* -1 if not set */
     int lfuFreq;            /* -1 if not set */
     int opcode;
+    int dataType;          /* See enum RdbDataType */
 } RdbKeyInfo;
 
 typedef struct RdbSlotInfo {

--- a/api/librdb-ext-api.h
+++ b/api/librdb-ext-api.h
@@ -15,6 +15,7 @@ typedef struct RdbxReaderFileDesc RdbxReaderFileDesc;
 typedef struct RdbxFilter RdbxFilter;
 typedef struct RdbxToJson RdbxToJson;
 typedef struct RdbxToResp RdbxToResp;
+typedef struct RdbxToPrint RdbxToPrint;
 typedef struct RdbxRespToRedisLoader RdbxRespToRedisLoader;
 
 /****************************************************************
@@ -94,6 +95,28 @@ _LIBRDB_API RdbxToJson *RDBX_createHandlersToJson(RdbParser *p,
                                                   RdbxToJsonConf *c);
 
 /****************************************************************
+ * Create PRINT Handlers
+ *
+ * auxFmt - Format string for auxiliary values, where:
+ *          %f = Auxiliary field name
+ *          %v = Auxiliary field value
+ * keyFmt - Format string for key details, where:
+ *          %d = Database number
+ *          %k = Key
+ *          %v = Value (If the value is a string, it will be printed as escaped string)
+ *          %t = Type
+ *          %e = Expiry
+ *          %r = LRU
+ *          %f = LFU
+ *          %i = Items
+ *
+ ****************************************************************/
+_LIBRDB_API RdbxToPrint *RDBX_createHandlersToPrint(RdbParser *p,
+                                                    const char *auxFmt,
+                                                    const char *keyFmt,
+                                                    const char *outFilename);
+
+/****************************************************************
  * Create Filter Handlers
  ****************************************************************/
 
@@ -108,6 +131,9 @@ _LIBRDB_API RdbxFilter *RDBX_createHandlersFilterType(RdbParser *p,
 _LIBRDB_API RdbxFilter *RDBX_createHandlersFilterDbNum(RdbParser *p,
                                                        int dbnum,
                                                        uint32_t exclude);
+
+_LIBRDB_API RdbxFilter *RDBX_createHandlersFilterExpired(RdbParser *p,
+                                                         uint32_t exclude);
 
 /****************************************************************
  * Create RDB to RESP Handlers

--- a/src/cli/rdb-cli.c
+++ b/src/cli/rdb-cli.c
@@ -22,14 +22,19 @@ typedef struct Options {
 
 void loggerWrap(RdbLogLevel l, const char *msg, ...);
 
-static int getOptArg(int argc, char* argv[], int *at, char *abbrvOpt, char *opt, int *flag, const char **arg) {
+/* This function checks if the current argument matches the given option or its
+ * abbreviation. If a match is found and an argument is expected, it retrieves the
+ * argument and stores it. It also sets a `flag` or read `extraArg` if provided.
+ */
+static int getOptArg(int argc, char* argv[], int *at, char *abbrvOpt, char *opt,
+                     int *flag, const char **extraArg) {
     if ((strcmp(argv[*at], abbrvOpt) == 0) || (strcmp(argv[*at], opt) == 0)) {
-        if (arg) {
+        if (extraArg) {
             if ((*at) + 1 == argc) {
                 fprintf(stderr, "%s (%s) requires one argument.", opt, abbrvOpt);
-                exit(RDB_ERR_GENERAL);
+                exit(1);
             }
-            *arg = argv[++(*at)];
+            *extraArg = argv[++(*at)];
         }
         if (flag) *flag = 1;
         return 1;
@@ -38,7 +43,13 @@ static int getOptArg(int argc, char* argv[], int *at, char *abbrvOpt, char *opt,
     }
 }
 
-static int getOptArgVal(int argc, char* argv[], int *at, char *abbrvOpt, char *opt, int *flag, int *val, int min, int max) {
+/* This function checks if the current argument matches the given option or its
+ * abbreviation. If a match is found, it retrieves the argument, converts it to
+ * an integer, and verifies that it is within the specified boundaries. It also
+ * sets a `flag` if provided.
+ */
+static int getOptArgVal(int argc, char* argv[], int *at, char *abbrvOpt, char *opt,
+                        int *flag, int *val, int min, int max) {
     const char *valStr;
     if (getOptArg(argc, argv, at,  abbrvOpt, opt, flag, &valStr)) {
 
@@ -46,8 +57,9 @@ static int getOptArgVal(int argc, char* argv[], int *at, char *abbrvOpt, char *o
 
         /* check boundaries. Condition support also the limits INT_MAX and INT_MIN. */
         if (!((*val>=min) && (*val <=max))) {
-            loggerWrap(RDB_LOG_ERR, "Value of %s (%s) must be a integer between %d and %d", opt, abbrvOpt, min, max);
-            exit(RDB_ERR_GENERAL);
+            loggerWrap(RDB_LOG_ERR, "Value of %s (%s) must be a integer between %d and %d",
+                       opt, abbrvOpt, min, max);
+            exit(1);
         }
         return 1;
     }
@@ -137,7 +149,8 @@ static RdbRes formatJson(RdbParser *parser, int argc, char **argv) {
     extern const char *jsonMetaPrefix;
     const char *includeArg;
     const char *output = NULL;/*default:stdout*/
-    int includeDbInfo=0, includeStreamMeta=0, includeFunc=0, includeAuxField=0, flatten=0; /*without*/
+    int includeDbInfo=0, includeStreamMeta=0, includeFunc=0, includeAuxField=0,
+        flatten=0;
 
     /* parse specific command options */
     for (int at = 1; at < argc; ++at) {
@@ -325,9 +338,10 @@ int matchRdbDataType(const char *dataTypeStr) {
     if (!strcmp(dataTypeStr, "stream")) return RDB_DATA_TYPE_STREAM;
     if (!strcmp(dataTypeStr, "func")) return RDB_DATA_TYPE_FUNCTION;
 
-    loggerWrap(RDB_LOG_ERR, "Invalid TYPE argument (%s). Valid values: str, list, set, zset, hash, module, stream, func",
+    loggerWrap(RDB_LOG_ERR,
+               "Invalid TYPE argument (%s). Valid values: str, list, set, zset, hash, module, stream, func",
                dataTypeStr);
-    exit(RDB_ERR_GENERAL);
+    exit(1);
 }
 
 int readCommonOptions(RdbParser *p, int argc, char* argv[], Options *options, int applyFilters) {
@@ -348,49 +362,49 @@ int readCommonOptions(RdbParser *p, int argc, char* argv[], Options *options, in
 
         if (getOptArg(argc, argv, &at, "-k", "--key", NULL, &keyFilter)) {
             if (applyFilters && (!RDBX_createHandlersFilterKey(p, keyFilter, 0)))
-                exit(RDBX_ERR_FAILED_CREATE_FILTER);
+                exit(1);
             continue;
         }
 
         if (getOptArg(argc, argv, &at, "-K", "--no-key", NULL, &keyFilter)) {
             if (applyFilters && (!RDBX_createHandlersFilterKey(p, keyFilter, 1)))
-                exit(RDBX_ERR_FAILED_CREATE_FILTER);
+                exit(1);
             continue;
         }
 
         if (getOptArg(argc, argv, &at, "-t", "--type", NULL, &typeFilter)) {
             if ((applyFilters) && (!RDBX_createHandlersFilterType(p, matchRdbDataType(typeFilter), 0)))
-                exit(RDBX_ERR_FAILED_CREATE_FILTER);
+                exit(1);
             continue;
         }
 
         if (getOptArg(argc, argv, &at, "-T", "--no-type", NULL, &typeFilter)) {
             if ((applyFilters) && (!RDBX_createHandlersFilterType(p, matchRdbDataType(typeFilter), 1)))
-                exit(RDBX_ERR_FAILED_CREATE_FILTER);
+                exit(1);
             continue;
         }
 
         if (getOptArgVal(argc, argv, &at, "-d", "--dbnum", NULL, &dbNumFilter, 0, INT_MAX)) {
             if ((applyFilters) && (!RDBX_createHandlersFilterDbNum(p, dbNumFilter, 0)))
-                exit(RDBX_ERR_FAILED_CREATE_FILTER);
+                exit(1);
             continue;
         }
 
         if (getOptArgVal(argc, argv, &at, "-D", "--no-dbnum", NULL, &dbNumFilter, 0, INT_MAX)) {
             if ((applyFilters) && (!RDBX_createHandlersFilterDbNum(p, dbNumFilter, 1)))
-                exit(RDBX_ERR_FAILED_CREATE_FILTER);
+                exit(1);
             continue;
         }
 
         if (getOptArg(argc, argv, &at, "-e", "--expired", NULL, NULL)) {
             if ((applyFilters) && (!RDBX_createHandlersFilterExpired(p, 0)))
-                exit(RDBX_ERR_FAILED_CREATE_FILTER);
+                exit(1);
             continue;
         }
 
         if (getOptArg(argc, argv, &at, "-E", "--no-expired", NULL, NULL)) {
             if ((applyFilters) && (!RDBX_createHandlersFilterExpired(p, 1)))
-                exit(RDBX_ERR_FAILED_CREATE_FILTER);
+                exit(1);
             continue;
         }
 
@@ -401,7 +415,7 @@ int readCommonOptions(RdbParser *p, int argc, char* argv[], Options *options, in
 
         loggerWrap(RDB_LOG_ERR, "At argv[%d], unexpected OPTIONS argument: %s\n", at, opt);
         printUsage(1);
-        exit(RDB_ERR_GENERAL);
+        exit(1);
     }
     return at;
 }
@@ -438,7 +452,8 @@ int main(int argc, char **argv)
     }
 
     if ((logfile = fopen(options.logfilePath, "w")) == NULL) {
-        printf("Error opening log file for writing `%s`: %s\n", options.logfilePath, strerror(errno));
+        printf("Error opening log file for writing `%s`: %s\n",
+               options.logfilePath, strerror(errno));
         return RDB_ERR_GENERAL;
     }
 

--- a/src/cli/rdb-cli.c
+++ b/src/cli/rdb-cli.c
@@ -85,16 +85,23 @@ static void printUsage(int shortUsage) {
         return;
     }
     printf("[v%s] ", RDB_getLibVersion(NULL,NULL,NULL));
-    printf("Usage: rdb-cli /path/to/dump.rdb [OPTIONS] {json|resp|redis} [FORMAT_OPTIONS]\n");
+    printf("Usage: rdb-cli /path/to/dump.rdb [OPTIONS] {print|json|resp|redis} [FORMAT_OPTIONS]\n");
     printf("OPTIONS:\n");
-    printf("\t-l, --log-file <PATH>         Path to the log file or stdout (Default: './rdb-cli.log')\n\n");
-    printf("\tMultiple filters combination of keys/types/dbs can be specified:\n");
+    printf("\t-l, --log-file <PATH>         Path to the log file or stdout (Default: './rdb-cli.log')\n");
     printf("\t-k, --key <REGEX>             Include only keys that match REGEX\n");
     printf("\t-K  --no-key <REGEX>          Exclude all keys that match REGEX\n");
     printf("\t-t, --type <TYPE>             Include only selected TYPE {str|list|set|zset|hash|module|func}\n");
     printf("\t-T, --no-type <TYPE>          Exclude TYPE {str|list|set|zset|hash|module|func}\n");
     printf("\t-d, --dbnum <DBNUM>           Include only selected db number\n");
-    printf("\t-D, --no-dbnum <DBNUM>        Exclude DB number\n\n");
+    printf("\t-D, --no-dbnum <DBNUM>        Exclude DB number\n");
+    printf("\t-e, --expired                 Include only expired keys\n");
+    printf("\t-E, --no-expired              Exclude expired keys\n\n");
+
+    printf("FORMAT_OPTIONS ('print'):\n");
+    printf("\t-a, --aux-val <FMT>           %%f=Auxiliary-Field, %%v=Auxiliary-Value (Default: \"\") \n");
+    printf("\t-k, --key <FMT>               %%d=Db %%k=Key %%v=Value %%t=Type %%e=Expiry %%r=LRU %%f=LFU %%i=Items\n");
+    printf("\t                              (Default: \"%%d,%%k,%%v,%%t,%%e,%%i\")\n");
+    printf("\t-o, --output <FILE>           Specify the output file. If not specified, output to stdout\n\n");
 
     printf("FORMAT_OPTIONS ('json'):\n");
     printf("\t-i, --include <EXTRAS>        To include: {aux-val|func|stream-meta|db-info}\n");
@@ -164,6 +171,27 @@ static RdbRes formatJson(RdbParser *parser, int argc, char **argv) {
     };
 
     if (RDBX_createHandlersToJson(parser, output, &conf) == NULL)
+        return RDB_ERR_GENERAL;
+
+    return RDB_OK;
+}
+
+static RdbRes formatPrint(RdbParser *parser, int argc, char **argv) {
+    const char *auxFmt = NULL, *keyFmt = "%d,%k,%v,%t,%e,%i";
+    const char *output = NULL;/*default:stdout*/
+
+    /* parse specific command options */
+    for (int at = 1; at < argc; ++at) {
+        char *opt = argv[at];
+        if (getOptArg(argc, argv, &at, "-o", "--output", NULL, &output)) continue;
+        if (getOptArg(argc, argv, &at, "-a", "--aux-val", NULL, &auxFmt)) continue;
+        if (getOptArg(argc, argv, &at, "-k", "--key", NULL, &keyFmt)) continue;
+        loggerWrap(RDB_LOG_ERR, "Invalid 'print' [FORMAT_OPTIONS] argument: %s\n", opt);
+        printUsage(1);
+        return RDB_ERR_GENERAL;
+    }
+
+    if (RDBX_createHandlersToPrint(parser, auxFmt, keyFmt, output) == NULL)
         return RDB_ERR_GENERAL;
 
     return RDB_OK;
@@ -354,9 +382,22 @@ int readCommonOptions(RdbParser *p, int argc, char* argv[], Options *options, in
             continue;
         }
 
+        if (getOptArg(argc, argv, &at, "-e", "--expired", NULL, NULL)) {
+            if ((applyFilters) && (!RDBX_createHandlersFilterExpired(p, 0)))
+                exit(RDBX_ERR_FAILED_CREATE_FILTER);
+            continue;
+        }
+
+        if (getOptArg(argc, argv, &at, "-E", "--no-expired", NULL, NULL)) {
+            if ((applyFilters) && (!RDBX_createHandlersFilterExpired(p, 1)))
+                exit(RDBX_ERR_FAILED_CREATE_FILTER);
+            continue;
+        }
+
         if (strcmp(opt, "json") == 0) { options->formatFunc = formatJson; break; }
         else if (strcmp(opt, "resp") == 0) { options->formatFunc = formatResp; break; }
         else if (strcmp(opt, "redis") == 0) { options->formatFunc = formatRedis; break; }
+        else if (strcmp(opt, "print") == 0) { options->formatFunc = formatPrint; break; }
 
         loggerWrap(RDB_LOG_ERR, "At argv[%d], unexpected OPTIONS argument: %s\n", at, opt);
         printUsage(1);

--- a/src/ext/handlersToJson.c
+++ b/src/ext/handlersToJson.c
@@ -60,8 +60,8 @@ struct RdbxToJson {
 const char *jsonMetaPrefix = "__";  /* Distinct meta from data with prefix string. */
 
 static void outputPlainEscaping(RdbxToJson *ctx, char *p, size_t len) {
-    while(len--) {
-        switch(*p) {
+    while (len--) {
+        switch (*p) {
             case '\\':
             case '"':
                 fprintf(ctx->outfile, "\\%c", *p); break;
@@ -105,7 +105,8 @@ static RdbxToJson *initRdbToJsonCtx(RdbParser *p, const char *outfilename, RdbxT
         outfilename = _STDOUT_STR;
     } else if (!(f = fopen(outfilename, "w"))) {
         RDB_reportError(p, RDB_ERR_FAILED_OPEN_FILE,
-                        "HandlersRdbToJson: Failed to open file. errno=%d: %s", errno, strerror(errno));
+                        "HandlersRdbToJson: Failed to open file `%s`. errno=%d: %s",
+                        outfilename, errno, strerror(errno));
         return NULL;
     }
 

--- a/src/ext/handlersToPrint.c
+++ b/src/ext/handlersToPrint.c
@@ -1,0 +1,313 @@
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include "common.h"
+#include "../../deps/redis/util.h"
+
+struct RdbxToPrint;
+
+#define _STDOUT_STR "<stdout>"
+
+struct RdbxToPrint {
+    RdbParser *p;
+
+    int dbnum;
+    char *outfileName;  /* Holds output filename or equals _STDOUT_STR */    
+    FILE *outfile;    
+    const char *keyFmt;
+    const char *auxFmt;
+
+    struct {
+        int skip;
+        RdbBulkCopy key;
+        unsigned int keyLen;
+        RdbKeyInfo info;
+        unsigned long items;
+    } keyCtx;
+
+};
+
+static void deleteRdbToPrintCtx(RdbParser *p, void *data) {
+    RdbxToPrint *ctx = (RdbxToPrint *) data;
+
+    RDB_bulkCopyFree(p, ctx->keyCtx.key);
+
+    RDB_log(p, RDB_LOG_DBG, "handlersToPrint: Closing file %s", ctx->outfileName);
+
+    if ((ctx->outfile) && (ctx->outfile != stdout))
+        fclose(ctx->outfile);
+
+    RDB_free(p, ctx->outfileName);
+    RDB_free(p, ctx);
+}
+
+static RdbxToPrint *initRdbToPrintCtx(RdbParser *p, const char *auxFmt,
+                                      const char *keyFmt,
+                                      const char *outFilename) {
+    FILE *f;
+
+    if (outFilename == NULL) {
+        f = stdout;
+        outFilename = _STDOUT_STR;
+    } else if (!(f = fopen(outFilename, "w"))) {
+        RDB_reportError(p, RDB_ERR_FAILED_OPEN_FILE,
+                        "HandlersRdbToPrint: Failed to open file. errno=%d: %s", errno, strerror(errno));
+        return NULL;
+    }
+
+    RDB_log(p, RDB_LOG_DBG, "handlersToPrint: Opening file %s", outFilename);
+
+    RdbxToPrint *ctx = RDB_alloc(p, sizeof(RdbxToPrint));
+    memset(ctx, 0, sizeof(RdbxToPrint));
+    ctx->p = p;
+    ctx->auxFmt = auxFmt;
+    ctx->keyFmt = keyFmt;
+    ctx->outfile = f;
+    ctx->outfileName = RDB_alloc(p, strlen(outFilename) + 1);
+    strcpy(ctx->outfileName, outFilename);
+    return ctx;
+}
+
+static void outputPlainEscaping(RdbxToPrint *ctx, char *p, size_t len) {
+    while(len--) {
+        switch(*p) {
+            case '\\':
+            case '"':
+                fprintf(ctx->outfile, "\\%c", *p); break;
+            case '\n': fprintf(ctx->outfile, "\\n"); break;
+            case '\f': fprintf(ctx->outfile, "\\f"); break;
+            case '\r': fprintf(ctx->outfile, "\\r"); break;
+            case '\t': fprintf(ctx->outfile, "\\t"); break;
+            case '\b': fprintf(ctx->outfile, "\\b"); break;
+            default:
+                fprintf(ctx->outfile, (isprint(*p)) ? "%c" : "\\u%04x", (unsigned char)*p);
+        }
+        p++;
+    }
+}
+
+static void printKeyFmt(RdbxToPrint *ctx, RdbBulk string) {
+    const char *p = ctx->keyFmt;
+
+    if (ctx->keyFmt[0] == '\0') return; /* if not FMT for keys */
+
+    while (*p) {
+        if (*p == '%') {
+            p++;
+            switch (*p) {
+                case 'd':
+                    fprintf(ctx->outfile, "%d", ctx->dbnum);
+                    break;
+                case 'k':
+                    outputPlainEscaping(ctx, ctx->keyCtx.key, ctx->keyCtx.keyLen);
+                    break;
+                case 'v':
+                    if (string)
+                        outputPlainEscaping(ctx, string, RDB_bulkLen(ctx->p, string));
+                    else
+                        fprintf(ctx->outfile, "{...}");
+                    break;
+                case 't':
+                {
+                    switch (ctx->keyCtx.info.dataType)
+                    {
+                        case RDB_DATA_TYPE_STRING:
+                            fprintf(ctx->outfile, "string");
+                            break;
+                        case RDB_DATA_TYPE_LIST:
+                            fprintf(ctx->outfile, "list");
+                            break;
+                        case RDB_DATA_TYPE_SET:
+                            fprintf(ctx->outfile, "set");
+                            break;
+                        case RDB_DATA_TYPE_ZSET:
+                            fprintf(ctx->outfile, "zset");
+                            break;
+                        case RDB_DATA_TYPE_HASH:
+                            fprintf(ctx->outfile, "hash");
+                            break;
+                        case RDB_DATA_TYPE_STREAM:
+                            fprintf(ctx->outfile, "stream");
+                            break;
+                        default:
+                            fprintf(ctx->outfile, "unknown");
+                    }
+
+                }
+                    break;
+                case 'e':
+                    fprintf(ctx->outfile, "%lld", ctx->keyCtx.info.expiretime);
+                    break;
+                case 'r':
+                    fprintf(ctx->outfile, "%lld", ctx->keyCtx.info.lruIdle);
+                    break;
+                case 'f':
+                    fprintf(ctx->outfile, "%d", ctx->keyCtx.info.lfuFreq);
+                    break;
+                case 'i':
+                    fprintf(ctx->outfile, "%ld", ctx->keyCtx.items);
+                    break;
+                default:
+                    fprintf(ctx->outfile, "%%");
+                    fprintf(ctx->outfile, "%c", *p);
+            }
+        } else {
+            fputc(*p, ctx->outfile);
+        }
+        p++;
+    }
+    fputc('\n', ctx->outfile);
+}
+
+static void printAuxFmt(RdbxToPrint *ctx, RdbBulk field, RdbBulk value) {
+    const char *p = ctx->auxFmt;
+    while (*p) {
+        if (*p == '%') {
+            p++;
+            switch (*p) {
+                case 'f':
+                    outputPlainEscaping(ctx, field, RDB_bulkLen(ctx->p, field));
+                    break;
+                case 'v':
+                    outputPlainEscaping(ctx, value, RDB_bulkLen(ctx->p, value));
+                    break;
+                default:
+                    fprintf(ctx->outfile, "%%");
+                    fprintf(ctx->outfile, "%c", *p);
+            }
+        } else {
+            fputc(*p, ctx->outfile);
+        }
+        p++;
+    }
+    fputc('\n', ctx->outfile);
+}
+
+/*** Handling common ***/
+
+static RdbRes toPrintAuxField(RdbParser *p, void *userData, RdbBulk auxkey, RdbBulk auxval) {
+    UNUSED(p);
+    RdbxToPrint *ctx = userData;
+    printAuxFmt(ctx, auxkey, auxval);
+    return RDB_OK;
+}
+
+static RdbRes toPrintEndKey(RdbParser *p, void *userData) {
+    RdbxToPrint *ctx = userData;
+
+    /* Print the key now that we gather all the information */
+    if (ctx->keyCtx.skip == 0)
+        printKeyFmt(ctx, NULL);
+
+    RDB_bulkCopyFree(p, ctx->keyCtx.key);
+    ctx->keyCtx.key = NULL;
+    return RDB_OK;
+}
+
+static RdbRes toPrintNewKey(RdbParser *p, void *userData, RdbBulk key, RdbKeyInfo *info) {
+    RdbxToPrint *ctx = userData;
+    ctx->keyCtx.key = RDB_bulkClone(p, key);
+    ctx->keyCtx.keyLen = RDB_bulkLen(p, key);
+    ctx->keyCtx.info = *info;
+    ctx->keyCtx.skip = 0;
+    ctx->keyCtx.items = 0;
+    return RDB_OK;
+}
+
+static RdbRes toPrintNewDb(RdbParser *p, void *userData, int db) {
+    UNUSED(p);
+    RdbxToPrint *ctx = userData;
+    ctx->dbnum = db;
+    return RDB_OK;
+}
+
+/*** Handling data ***/
+
+static RdbRes toPrintString(RdbParser *p, void *userData, RdbBulk string) {
+    UNUSED(p);
+    RdbxToPrint *ctx = userData;
+    /* print the key now that we gather all the information */
+    printKeyFmt(ctx, string);
+    ctx->keyCtx.skip = 1;
+    return RDB_OK;
+}
+
+static RdbRes toPrintList(RdbParser *p, void *userData, RdbBulk item) {
+    UNUSED(p, item);
+    RdbxToPrint *ctx = userData;
+    ctx->keyCtx.items++;
+    return RDB_OK;
+}
+
+static RdbRes toPrintSet(RdbParser *p, void *userData, RdbBulk member) {
+    UNUSED(p, member);
+    RdbxToPrint *ctx = userData;
+    ctx->keyCtx.items++;
+    return RDB_OK;
+}
+
+static RdbRes toPrintZset(RdbParser *p, void *userData, RdbBulk member, double score) {
+    UNUSED(p, member, score);
+    RdbxToPrint *ctx = userData;
+    ctx->keyCtx.items++;
+    return RDB_OK;
+}
+
+static RdbRes toPrintHash(RdbParser *p, void *userData, RdbBulk field,
+                         RdbBulk value, int64_t expireAt)
+{
+    UNUSED(p, field, value, expireAt);
+    RdbxToPrint *ctx = userData;
+    ctx->keyCtx.items++;
+    return RDB_OK;
+}
+
+static RdbRes toPrintStreamItem(RdbParser *p, void *userData, RdbStreamID *id, RdbBulk field, RdbBulk value, int64_t itemsLeft) {
+    UNUSED(p, id, field, value, itemsLeft);
+    RdbxToPrint *ctx = userData;
+    ctx->keyCtx.items++;
+    return RDB_OK;
+}
+
+/*** API ***/
+
+RdbxToPrint *RDBX_createHandlersToPrint(RdbParser *p,
+                                        const char *auxFmt,
+                                        const char *keyFmt,
+                                        const char *outFilename)
+{
+    RdbxToPrint *ctx = initRdbToPrintCtx(p, auxFmt, keyFmt, outFilename);
+    if (ctx == NULL) return NULL;
+
+    RdbHandlersDataCallbacks dataCb = {
+            NULL,
+            NULL,
+            toPrintNewDb,
+            NULL, /*handleDbSize*/
+            NULL, /*handleSlotInfo*/
+            NULL, /*handleAuxField*/
+            toPrintNewKey,
+            toPrintEndKey,
+            toPrintString,
+            toPrintList,
+            toPrintHash,
+            toPrintSet,
+            toPrintZset,
+            NULL, /*handleFunction*/
+            NULL, /*handleModule*/
+            NULL, /*handleStreamMetadata*/
+            toPrintStreamItem,
+            NULL, /*handleStreamNewCGroup*/
+            NULL, /*handleStreamCGroupPendingEntry*/
+            NULL, /*handleStreamNewConsumer*/
+            NULL, /*handleStreamConsumerPendingEntry*/
+    };
+
+    if (auxFmt)
+        dataCb.handleAuxField = toPrintAuxField;
+
+    RDB_createHandlersData(p, &dataCb, ctx, deleteRdbToPrintCtx);
+
+    return ctx;
+}

--- a/src/ext/handlersToPrint.c
+++ b/src/ext/handlersToPrint.c
@@ -29,7 +29,7 @@ struct RdbxToPrint {
 };
 
 static void deleteRdbToPrintCtx(RdbParser *p, void *data) {
-    RdbxToPrint *ctx = (RdbxToPrint *) data;
+    RdbxToPrint *ctx = data;
 
     RDB_bulkCopyFree(p, ctx->keyCtx.key);
 
@@ -52,7 +52,8 @@ static RdbxToPrint *initRdbToPrintCtx(RdbParser *p, const char *auxFmt,
         outFilename = _STDOUT_STR;
     } else if (!(f = fopen(outFilename, "w"))) {
         RDB_reportError(p, RDB_ERR_FAILED_OPEN_FILE,
-                        "HandlersRdbToPrint: Failed to open file. errno=%d: %s", errno, strerror(errno));
+                        "HandlersRdbToPrint: Failed to open file `%s`. errno=%d: %s",
+                        outFilename, errno, strerror(errno));
         return NULL;
     }
 
@@ -70,8 +71,8 @@ static RdbxToPrint *initRdbToPrintCtx(RdbParser *p, const char *auxFmt,
 }
 
 static void outputPlainEscaping(RdbxToPrint *ctx, char *p, size_t len) {
-    while(len--) {
-        switch(*p) {
+    while (len--) {
+        switch (*p) {
             case '\\':
             case '"':
                 fprintf(ctx->outfile, "\\%c", *p); break;

--- a/src/ext/respToFileWriter.c
+++ b/src/ext/respToFileWriter.c
@@ -54,7 +54,7 @@ RdbxRespToFileWriter *RDBX_createRespToFileWriter(RdbParser *p, RdbxToResp *rdbT
     } else {
         filePtr = fopen(filePath, "wb");
         if (filePtr == NULL) {
-            RDB_reportError(p, RDB_ERR_FAILED_OPEN_FILE, "createRespWriter: Failed to open file: %s. errno:%d",
+            RDB_reportError(p, RDB_ERR_FAILED_OPEN_FILE, "createRespWriter: Failed to open file: `%s`. errno:%d",
                             filePath, errno);
             return NULL;
         }

--- a/test/Makefile
+++ b/test/Makefile
@@ -19,7 +19,7 @@ WARNS       = -Wall -Wextra -pedantic -Werror -Wno-unused-function
 
 OPTIMIZATION?=-O0
 
-CFLAGS      = -fPIC $(OPTIMIZATION) $(STD) $(STACK) $(WARNS)
+CFLAGS      = -D_DEFAULT_SOURCE -fPIC $(OPTIMIZATION) $(STD) $(STACK) $(WARNS)
 DEBUG       = -g3 -DDEBUG=1
 LIBS        = -l cmocka -L /usr/lib -L $(LIB_DIR) -l $(LIB_NAME) -l $(LIB_NAME_EXT) -l:$(LIBHIREDIS)
 LIBS_STATIC = -l cmocka -L /usr/lib -L $(LIB_DIR) -l:lib$(LIB_NAME_EXT).a -l:$(LIBHIREDIS)

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -36,7 +36,7 @@ typedef enum MatchType {
 } MatchType;
 
 /* system() commands */
-void runSystemCmd(const char *cmdFormat, ...);
+char *runSystemCmd(const char *cmdFormat, ...);
 
 /* assert */
 void assert_json_equal(const char *f1, const char *f2, int ignoreListOrder);

--- a/test/test_rdb_cli.c
+++ b/test/test_rdb_cli.c
@@ -1,5 +1,5 @@
 #include <string.h>
-#include <stdlib.h>
+#include <unistd.h>
 #include "test_common.h"
 
 static int setupTest(void **state) {
@@ -74,30 +74,26 @@ static void test_rdb_cli_resp_to_redis(void **state) {
 
 static void test_rdb_cli_filter_db(void **state) {
     UNUSED(state);
+    char *output;
     /* -d/--dbnum 0 (found x but not y or z) */
-    runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_dbs.rdb -d 0 json -f > ./test/tmp/rdb_cli_filter_db1.json ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_db1.json | grep x > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_db1.json | grep y && exit 1 || exit 0 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_db1.json | grep z && exit 1 || exit 0 > /dev/null ");
+    output =  runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_dbs.rdb -d 0 print -k \"%%k\" | sort");
+    assert_string_equal(output, "x\n");
+
     /* -D/--no-dbnum 0 (found y and z but not x) */
-    runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_dbs.rdb --no-dbnum 0 json -f > ./test/tmp/rdb_cli_filter_db2.json ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_db2.json | grep x && exit 1 || exit 0 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_db2.json | grep y > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_db2.json | grep z > /dev/null ");
+    output = runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_dbs.rdb --no-dbnum 0 print -k \"%%k\" | sort");
+    assert_string_equal(output, "y\nz\n");
 }
 
 static void test_rdb_cli_filter_key(void **state) {
+    char *output;
     UNUSED(state);
     /* -k/--key (found string2 but not mylist1 or lzf_compressed) */
-    runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb -k string2 json -f > ./test/tmp/rdb_cli_filter_key1.json ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_key1.json | grep string2 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_key1.json | grep mylist1 && exit 1 || exit 0 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_key1.json | grep lzf_compressed && exit 1 || exit 0 > /dev/null ");
+    output = runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb -k string2 print -k \"%%k\" | sort");
+    assert_string_equal(output, "string2\n");
+
     /* -K/--no-key (found mylist1 or lzf_compressed but not string2) */
-    runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb -K string2 json -f > ./test/tmp/rdb_cli_filter_key2.json ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_key2.json | grep string2 && exit 1 || exit 0 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_key2.json | grep mylist1 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_key2.json | grep lzf_compressed > /dev/null ");
+    output = runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb -K string2 print -k \"%%k\" | sort");
+    assert_string_equal(output, "lzf_compressed\nmylist1\nmylist2\nmylist3\nstring1\n");
 }
 
 static void test_rdb_cli_filter_invalid_input(void **state) {
@@ -108,43 +104,55 @@ static void test_rdb_cli_filter_invalid_input(void **state) {
 
 static void test_rdb_cli_filter_type(void **state) {
     UNUSED(state);
+    char *output;
     /* -t/--type */
-    runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb --type str json -f > ./test/tmp/rdb_cli_filter_type1.json ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_type1.json | grep string2 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_type1.json | grep lzf_compressed > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_type1.json | grep string1 > /dev/null ");
-    runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb -t str json -f > ./test/tmp/rdb_cli_filter_type2.json ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_type2.json | grep mylist1 && exit 1 || exit 0 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_type2.json | grep mylist2 && exit 1 || exit 0 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_type2.json | grep mylist3 && exit 1 || exit 0 > /dev/null ");
+    output = runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb --type str print -k \"%%k\" | sort");
+    assert_string_equal(output, "lzf_compressed\nstring1\nstring2\n");
+
+    output = runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb -t str print -k \"%%k\" | sort");
+    assert_string_equal(output, "lzf_compressed\nstring1\nstring2\n");
 
     /* -T/--no-type */
-    runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb --no-type str json -f > ./test/tmp/rdb_cli_filter_type3.json ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_type3.json | grep mylist1 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_type3.json | grep mylist2 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_type3.json | grep mylist3 > /dev/null ");
-    runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb -T str json -f >  ./test/tmp/rdb_cli_filter_type4.json ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_type4.json | grep string2 && exit 1 || exit 0 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_type4.json | grep lzf_compressed && exit 1 || exit 0 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_type4.json | grep string1 && exit 1 || exit 0 > /dev/null ");
+    output = runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb --no-type str print -k \"%%k\" | sort");
+    assert_string_equal(output, "mylist1\nmylist2\nmylist3\n");
+
+    output = runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb -T str print -k \"%%k\" | sort");
+    assert_string_equal(output, "mylist1\nmylist2\nmylist3\n");
+}
+
+static void test_rdb_cli_filter_expire(void **state) {
+    UNUSED(state);
+    char *output;
+    sendRedisCmd("SET persistKey STAM", REDIS_REPLY_STATUS, NULL);
+    sendRedisCmd("SET volatileKey XXX", REDIS_REPLY_STATUS, NULL);
+    sendRedisCmd("HSET persistHash f1 v1", REDIS_REPLY_INTEGER, "1");
+    sendRedisCmd("SAVE", REDIS_REPLY_STATUS, NULL);
+    sendRedisCmd("PEXPIRE volatileKey 10", REDIS_REPLY_INTEGER, "1");
+    sendRedisCmd("SAVE", REDIS_REPLY_STATUS, NULL);
+    runSystemCmd("cp %s %s > /dev/null", TMP_FOLDER("dump.rdb"), TMP_FOLDER("test_rdb_cli_print.rdb"));
+    usleep(20000); /*20ms*/
+    output = runSystemCmd("$RDB_CLI_CMD %s print -k \"%%k\" | sort", TMP_FOLDER("test_rdb_cli_print.rdb"));
+    assert_string_equal(output, "persistHash\npersistKey\nvolatileKey\n");
+    output = runSystemCmd("$RDB_CLI_CMD %s -e print -k \"%%k\" | sort", TMP_FOLDER("test_rdb_cli_print.rdb"));
+    assert_string_equal(output, "volatileKey\n");
+    output = runSystemCmd("$RDB_CLI_CMD %s -E print | sort", TMP_FOLDER("test_rdb_cli_print.rdb"));
+    assert_string_equal(output, "0,persistHash,{...},hash,-1,1\n0,persistKey,STAM,string,-1,0\n");
 }
 
 static void test_rdb_cli_filter_mix(void **state) {
     UNUSED(state);
+    char *output;
     /* Combine 'type' and 'key' filters */
-    runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb --type str --key string json -f > ./test/tmp/rdb_cli_filter_mix1.json ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_mix1.json | grep string2 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_mix1.json | grep string1 > /dev/null ");
-    runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb -t str -k string json -f  > ./test/tmp/rdb_cli_filter_mix2.json ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_mix2.json | grep lzf_compressed && exit 1 || exit 0 > /dev/null");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_mix2.json | grep list1 && exit 1 || exit 0 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_mix2.json | grep list2 && exit 1 || exit 0 > /dev/null ");
-    runSystemCmd(" cat ./test/tmp/rdb_cli_filter_mix2.json | grep list3 && exit 1 || exit 0 > /dev/null ");
+    output = runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb --type str --key string print -k \"%%k\" | sort");
+    assert_string_equal(output, "string1\nstring2\n");
+    output = runSystemCmd(" $RDB_CLI_CMD ./test/dumps/multiple_lists_strings.rdb -t str -k string print -k \"%%k\" | sort");
+    assert_string_equal(output, "string1\nstring2\n");
 }
 
 static void test_rdb_cli_input_fd_reader(void **state) {
     UNUSED(state);
-    runSystemCmd(" cat ./test/dumps/single_key.rdb | $RDB_CLI_CMD - json | grep xxx > /dev/null ");
+    char *out = runSystemCmd(" cat ./test/dumps/single_key.rdb | $RDB_CLI_CMD - print -k \"%%k\" | sort");
+    assert_string_equal(out, "xxx\n");
 }
 
 static void test_rdb_cli_redis_auth(void **state) {
@@ -176,6 +184,22 @@ static void test_rdb_cli_redis_auth(void **state) {
     teardownRedisServer();
 }
 
+static void test_rdb_cli_print(void **state) {
+    UNUSED(state);
+    char *output;
+    sendRedisCmd("SET ABC STAM", REDIS_REPLY_STATUS, NULL);
+    sendRedisCmd("HSET myhash f1 v1", REDIS_REPLY_INTEGER, "1");
+    sendRedisCmd("SAVE", REDIS_REPLY_STATUS, NULL);
+
+    /* Check default ouput of print */
+    output = runSystemCmd("$RDB_CLI_CMD %s print | sort", TMP_FOLDER("dump.rdb"));
+    assert_string_equal(output, "0,ABC,STAM,string,-1,0\n0,myhash,{...},hash,-1,1\n");
+
+    /* Check customized output of print */
+    output = runSystemCmd("$RDB_CLI_CMD %s print -k \"%%k\" | sort", TMP_FOLDER("dump.rdb"));
+    assert_string_equal(output, "ABC\nmyhash\n");
+}
+
 /*************************** group_test_rdb_cli *******************************/
 int group_test_rdb_cli(void) {
 
@@ -191,9 +215,11 @@ int group_test_rdb_cli(void) {
             cmocka_unit_test_setup(test_rdb_cli_filter_key, setupTest),
             cmocka_unit_test_setup(test_rdb_cli_filter_invalid_input, setupTest),
             cmocka_unit_test_setup(test_rdb_cli_filter_type, setupTest),
+            cmocka_unit_test_setup(test_rdb_cli_filter_expire, setupTest),
             cmocka_unit_test_setup(test_rdb_cli_filter_mix, setupTest),
             cmocka_unit_test_setup(test_rdb_cli_input_fd_reader, setupTest),
             cmocka_unit_test_setup(test_rdb_cli_redis_auth, setupTest),
+            cmocka_unit_test_setup(test_rdb_cli_print, setupTest),
     };
 
     int res = cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Expand API with `RDBX_createHandlersToPrint()` that support printout customization via 
arguments `auxFmt` and `keyFmt`. Can later further refined to printout of `valueFmt`
by need, etc.

Expand API with `RDBX_createHandlersFilterExpired()` to filter based whether a given
key is expired.

Expand `rdb-cli` accordingly.