### PR TITLE
Add to rdb-cli options `--show-progress`

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ destruction, or when newer block replacing old one.
     Usage: rdb-cli /path/to/dump.rdb [OPTIONS] {print|json|resp|redis} [FORMAT_OPTIONS]
     OPTIONS:
             -l, --log-file <PATH>         Path to the log file or stdout (Default: './rdb-cli.log')
-            -s, --show-progress <INT>     Show progress after every <INT> megabytes processed
+            -s, --show-progress <MBytes>  Show progress to STDOUT after every <MBytes> processed
             -k, --key <REGEX>             Include only keys that match REGEX
             -K  --no-key <REGEX>          Exclude all keys that match REGEX
             -t, --type <TYPE>             Include only selected TYPE {str|list|set|zset|hash|module|func}

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ destruction, or when newer block replacing old one.
     Usage: rdb-cli /path/to/dump.rdb [OPTIONS] {print|json|resp|redis} [FORMAT_OPTIONS]
     OPTIONS:
             -l, --log-file <PATH>         Path to the log file or stdout (Default: './rdb-cli.log')
+            -s, --show-progress <INT>     Show progress after every <INT> megabytes processed
             -k, --key <REGEX>             Include only keys that match REGEX
             -K  --no-key <REGEX>          Exclude all keys that match REGEX
             -t, --type <TYPE>             Include only selected TYPE {str|list|set|zset|hash|module|func}


### PR DESCRIPTION
Usage:
```
 -s, --show-progress <INT>     Show progress after every <INT> megabytes processed
```
For example, adding `-s 10` or `--show-progress 10` will print: 
```
... Processed 10MBytes ...
... Processed 20MBytes ...
...
```