### PR TITLE
Support RDB_TYPE_HASH_METADATA relative time optimization

### DIFF
--- a/src/lib/parser.h
+++ b/src/lib/parser.h
@@ -211,6 +211,7 @@ typedef struct {
 typedef struct {
     uint64_t numFields;
     uint64_t visitingField;
+    int64_t hexpireMinMsec;
 } ElementHashCtx;
 
 typedef struct {


### PR DESCRIPTION
Adapt librdb to modified layout of RDB_TYPE_HASH_METADATA which 
now store field's relative TTLs instead of absolute expiration time.