### PR TITLE
Resolve Compilation Errors with ARM GCC on Ubuntu 22.04

### DIFF
--- a/src/ext/handlersToJson.c
+++ b/src/ext/handlersToJson.c
@@ -173,9 +173,9 @@ static RdbRes toJsonSlotInfo(RdbParser *p, void *userData, RdbSlotInfo *info) {
 
     /* output json part */
     fprintf(ctx->outfile, "    \"%sslotinfo__\": {\n", jsonMetaPrefix);
-    fprintf(ctx->outfile, "      \"slotId\": %lu,\n", info->slot_id);
-    fprintf(ctx->outfile, "      \"slotSize\": %lu,\n", info->slot_size);
-    fprintf(ctx->outfile, "      \"slotSExpiresSize\": %lu\n", info->expires_slot_size);
+    fprintf(ctx->outfile, "      \"slotId\": %" PRIu64 ",\n", info->slot_id);
+    fprintf(ctx->outfile, "      \"slotSize\": %" PRIu64 ",\n", info->slot_size);
+    fprintf(ctx->outfile, "      \"slotSExpiresSize\": %" PRIu64 "\n", info->expires_slot_size);
     fprintf(ctx->outfile, "    },\n");
     return RDB_OK;
 }
@@ -353,7 +353,7 @@ static RdbRes toJsonModule(RdbParser *p, void *userData, RdbBulk moduleName, siz
     }
 
     /* output json part */
-    fprintf(ctx->outfile, "\"<Content of Module '%s'. Occupies a serialized size of %ld bytes>\"",
+    fprintf(ctx->outfile, "\"<Content of Module '%s'. Occupies a serialized size of %zu bytes>\"",
             moduleName,
             serializedSize);
 
@@ -532,7 +532,7 @@ static RdbRes toJsonStreamItem(RdbParser *p, void *userData, RdbStreamID *id, Rd
             fprintf(ctx->outfile, "{\n      \"entries\":[");
 
         /* output another stream entry */
-        fprintf(ctx->outfile, "%c\n        { \"id\":\"%lu-%lu\", ",
+        fprintf(ctx->outfile, "%c\n        { \"id\":\"%" PRIu64 "-%" PRIu64 "\", ",
                 (ctx->state == R2J_IN_STREAM_ENTRIES) ? ',' : ' ',
                 id->ms, id->seq );
         fprintf(ctx->outfile, "\"items\":{");
@@ -570,11 +570,11 @@ static RdbRes toJsonStreamMetadata(RdbParser *p, void *userData, RdbStreamMeta *
         return (RdbRes) RDBX_ERR_R2J_INVALID_STATE;
     }
     ctx->state = R2J_IN_STREAM;
-    fprintf(ctx->outfile, "],\n      \"length\": %lu, ", meta->length);
-    fprintf(ctx->outfile, "\n      \"entriesAdded\": %lu, ", meta->entriesAdded);
-    fprintf(ctx->outfile, "\n      \"firstID\": \"%lu-%lu\", ", meta->firstID.ms, meta->firstID.seq);
-    fprintf(ctx->outfile, "\n      \"lastID\": \"%lu-%lu\", ", meta->lastID.ms, meta->lastID.seq);
-    fprintf(ctx->outfile, "\n      \"maxDelEntryID\": \"%lu-%lu\",", meta->maxDelEntryID.ms, meta->maxDelEntryID.seq);
+    fprintf(ctx->outfile, "],\n      \"length\": %" PRIu64 ", ", meta->length);
+    fprintf(ctx->outfile, "\n      \"entriesAdded\": %" PRIu64 ", ", meta->entriesAdded);
+    fprintf(ctx->outfile, "\n      \"firstID\": \"%" PRIu64 "-%" PRIu64 "\", ", meta->firstID.ms, meta->firstID.seq);
+    fprintf(ctx->outfile, "\n      \"lastID\": \"%" PRIu64 "-%" PRIu64 "\", ", meta->lastID.ms, meta->lastID.seq);
+    fprintf(ctx->outfile, "\n      \"maxDelEntryID\": \"%" PRIu64 "-%" PRIu64 "\",", meta->maxDelEntryID.ms, meta->maxDelEntryID.seq);
     return RDB_OK;
 }
 
@@ -596,7 +596,7 @@ static RdbRes toJsonStreamNewCGroup(RdbParser *p, void *userData, RdbBulk grpNam
                         "toJsonStreamNewCGroup(): Invalid state value: %d", ctx->state);
         return (RdbRes) RDBX_ERR_R2J_INVALID_STATE;
     }
-    fprintf(ctx->outfile, "%s        {\"name\": \"%s\", \"lastid\": \"%lu-%lu\", \"entriesRead\": %lu",
+    fprintf(ctx->outfile, "%s        {\"name\": \"%s\", \"lastid\": \"%" PRIu64 "-%" PRIu64 "\", \"entriesRead\": %" PRIu64,
             prefix, grpName, meta->lastId.ms, meta->lastId.seq, meta->entriesRead);
 
     ctx->state = R2J_IN_STREAM_CG;
@@ -616,7 +616,7 @@ static RdbRes toJsonStreamCGroupPendingEntry(RdbParser *p, void *userData, RdbSt
                         "toJsonStreamCGroupPendingEntry(): Invalid state value: %d", ctx->state);
         return (RdbRes) RDBX_ERR_R2J_INVALID_STATE;
     }
-    fprintf(ctx->outfile, "%s\n           { \"sent\": %lu, \"id\":\"%lu-%lu\", \"count\": %lu }",
+    fprintf(ctx->outfile, "%s\n           { \"sent\": %" PRIu64 ", \"id\":\"%" PRIu64 "-%" PRIu64 "\", \"count\": %" PRIu64 " }",
             prefix, pe->deliveryTime, pe->id.ms, pe->id.seq, pe->deliveryCount);
     return RDB_OK;
 }
@@ -659,7 +659,7 @@ static RdbRes toJsonStreamConsumerPendingEntry(RdbParser *p, void *userData, Rdb
     }
 
     ctx->state = R2J_IN_STREAM_CG_CONSUMER_PEL;
-    fprintf(ctx->outfile, "%s\n               {\"id\":\"%lu-%lu\"}", prefix, streamId->ms, streamId->seq);
+    fprintf(ctx->outfile, "%s\n               {\"id\":\"%" PRIu64 "-%" PRIu64 "\"}", prefix, streamId->ms, streamId->seq);
     return RDB_OK;
 }
 

--- a/src/ext/handlersToResp.c
+++ b/src/ext/handlersToResp.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <assert.h>
 #include <sys/uio.h>
+#include <inttypes.h>
 #include "common.h"
 
 #include "../../deps/redis/crc64.h"
@@ -641,8 +642,8 @@ static RdbRes toRespStreamMetaData(RdbParser *p, void *userData, RdbStreamMeta *
     /* take care to reset it for next stream-item */
     ctx->streamCtx.xaddStartEndCounter = 0;
 
-    int idLen = snprintf(idStr, sizeof(idStr), "%lu-%lu",meta->lastID.ms,meta->lastID.seq);
-    int maxDelEntryIdLen = snprintf(maxDelEntryId, sizeof(maxDelEntryId), "%lu-%lu", meta->maxDelEntryID.ms, meta->maxDelEntryID.seq);
+    int idLen = snprintf(idStr, sizeof(idStr), "%" PRIu64 "-%" PRIu64,meta->lastID.ms,meta->lastID.seq);
+    int maxDelEntryIdLen = snprintf(maxDelEntryId, sizeof(maxDelEntryId), "%" PRIu64 "-%" PRIu64, meta->maxDelEntryID.ms, meta->maxDelEntryID.seq);
 
     RdbxRespWriterStartCmd startCmd = {"XSETID", ctx->keyCtx.key, 0};
 
@@ -686,11 +687,11 @@ static RdbRes toRespStreamItem(RdbParser *p, void *userData, RdbStreamID *id, Rd
         startCmdRef = &startCmd;
 
         /* writev XADD */
-        int cmdLen = snprintf(cmd, sizeof(cmd), "*%lu\r\n$4\r\nXADD", 3 + (itemsLeft + 1) * 2);
+        int cmdLen = snprintf(cmd, sizeof(cmd), "*%" PRIu64 "\r\n$4\r\nXADD", 3 + (itemsLeft + 1) * 2);
         IOV_STRING(&iov[iovs++], cmd, cmdLen);
         IOV_LENGTH(&iov[iovs++], ctx->keyCtx.keyLen, keyLenStr);
         IOV_STRING(&iov[iovs++], ctx->keyCtx.key, ctx->keyCtx.keyLen);
-        int idLen = snprintf(idStr, sizeof(idStr), "%lu-%lu",id->ms,id->seq);
+        int idLen = snprintf(idStr, sizeof(idStr), "%" PRIu64 "-%" PRIu64,id->ms,id->seq);
         IOV_LENGTH(&iov[iovs++], idLen, idLenStr);
         IOV_STRING(&iov[iovs++], idStr, idLen);
 
@@ -731,7 +732,7 @@ static RdbRes toRespStreamNewCGroup(RdbParser *p, void *userData, RdbBulk grpNam
     if(!(ctx->streamCtx.groupPel = raxNew()))
         return RDB_ERR_FAIL_ALLOC;
 
-    int idLen = snprintf(idStr, sizeof(idStr), "%lu-%lu",meta->lastId.ms,meta->lastId.seq);
+    int idLen = snprintf(idStr, sizeof(idStr), "%" PRIu64 "-%" PRIu64,meta->lastId.ms,meta->lastId.seq);
 
     RdbxRespWriterStartCmd startCmd = { "XGROUP", ctx->keyCtx.key, 0};
 
@@ -828,7 +829,7 @@ static RdbRes toRespStreamConsumerPendingEntry(RdbParser *p, void *userData, Rdb
     IOV_LENGTH(&iov[iovs++], ctx->streamCtx.consNameLen, cNameLenStr);
     IOV_STRING(&iov[iovs++], ctx->streamCtx.consName, ctx->streamCtx.consNameLen);
     /* trailer of the command */
-    int idLen = snprintf(idStr, sizeof(idStr), "%lu-%lu",streamId->ms, streamId->seq);
+    int idLen = snprintf(idStr, sizeof(idStr), "%" PRIu64 "-%" PRIu64,streamId->ms, streamId->seq);
     int sentTimeLen = ll2string(sentTime, sizeof(sentTime), pe->deliveryTime);
     int sentCountLen = ll2string(sentCount, sizeof(sentCount), pe->deliveryCount);
     int cmdTrailerLen = snprintf(cmdTrailer, sizeof(cmdTrailer),

--- a/src/lib/parser.c
+++ b/src/lib/parser.c
@@ -2178,7 +2178,7 @@ RdbStatus elementModule(RdbParser *p) {
                     IF_NOT_OK_RETURN(rdbLoadLen(p, NULL, &when, NULL, NULL));
                     if (unlikely(when_opcode != RDB_MODULE_OPCODE_UINT)) {
                         RDB_reportError(p, RDB_ERR_MODULE_INVALID_WHEN_OPCODE,
-                            "elementModule() : Invalid when opcode: %ld.", when_opcode);
+                            "elementModule() : Invalid when opcode: %" PRIu64 ".", when_opcode);
                         return RDB_STATUS_ERROR;
                     }
                 }

--- a/src/lib/parserRaw.c
+++ b/src/lib/parserRaw.c
@@ -729,7 +729,7 @@ RdbStatus elementRawModule(RdbParser *p) {
                 IF_NOT_OK_RETURN(rdbLoadLen(p, NULL, &ma->when, NULL, NULL));
                 if (unlikely(ma->when_opcode != RDB_MODULE_OPCODE_UINT)) {
                     RDB_reportError(p, RDB_ERR_MODULE_INVALID_WHEN_OPCODE,
-                                    "elementRawModule() : Invalid when opcode: %ld.", ma->when_opcode);
+                                    "elementRawModule() : Invalid when opcode: %" PRIu64 ".", ma->when_opcode);
                     return RDB_STATUS_ERROR;
                 }
                 /*** ENTER SAFE STATE ***/
@@ -1214,7 +1214,7 @@ static RdbStatus aggMakeRoom(RdbParser *p, size_t numBytesRq) {
     size_t freeRoomLeft = currBuff->len - currBuff->written;
 
     if (unlikely(p->maxRawSize < ctx->totalSize + numBytesRq)) {
-        RDB_reportError(p, RDB_ERR_MAX_RAW_LEN_EXCEEDED_FOR_KEY, "Maximum raw length exceeded for key (len=%lu)",
+        RDB_reportError(p, RDB_ERR_MAX_RAW_LEN_EXCEEDED_FOR_KEY, "Maximum raw length exceeded for key (len=%zu)",
                         ctx->totalSize + numBytesRq);
         return RDB_STATUS_ERROR;
     }
@@ -1287,7 +1287,7 @@ void printAggAraryDbg(RdbParser *p) {
     RawContext *ctx = &p->rawCtx;
     for (int i = 0; i <= ctx->curBulkIndex ; ++i) {
         BulkInfo *b = ctx->bulkArray+i;
-        printf("bulkArray[%d]: bulkType=%d ref=%p len=%lu written=%lu next=%p\n",
+        printf("bulkArray[%d]: bulkType=%d ref=%p len=%zu written=%zu next=%p\n",
                i, b->bulkType, (void *)b->ref, b->len, b->written, (void *)b->next);
     }
 }


### PR DESCRIPTION
#### Why I did it
Fix the issue: https://github.com/redis/librdb/issues/52
The librdb may be used in ARM platforms, so this issue matters.

#### How I did it
The compile warnings were caused by the improper string format specifiers. So, fix them.

#### How to verify it
To refer https://github.com/redis/librdb/issues/52.
