### PR TITLE
Build hiredis only for 'make test' rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,20 +22,20 @@ export LIBRDB_VERSION
 
 # ------------------------- ALL --------------------------------------
 
-all:
-	$(MAKE) -C deps -f Makefile all
-	$(MAKE) -C src/lib -f Makefile all
-	$(MAKE) -C src/ext -f Makefile all
-	$(MAKE) -C src/cli -f Makefile all
-	$(MAKE) -C examples -f Makefile all
+all: ./deps/hiredis/hiredis.h
+	$(MAKE) -C deps  all
+	$(MAKE) -C src/lib  all
+	$(MAKE) -C src/ext  all
+	$(MAKE) -C src/cli  all
+	$(MAKE) -C examples  all
 
 clean:
-	$(MAKE) -C deps -f Makefile clean
-	$(MAKE) -C src/lib -f Makefile clean
-	$(MAKE) -C src/ext -f Makefile clean
-	$(MAKE) -C src/cli -f Makefile clean
-	$(MAKE) -C examples -f Makefile clean
-	$(MAKE) -C test -f Makefile clean
+	$(MAKE) -C deps  clean
+	$(MAKE) -C src/lib  clean
+	$(MAKE) -C src/ext  clean
+	$(MAKE) -C src/cli  clean
+	$(MAKE) -C examples  clean
+	$(MAKE) -C test  clean
 	rm -f librdb.pc
 	rm -f librdb-ext.pc
 
@@ -43,6 +43,9 @@ distclean: clean
 
 example: all
 	cd examples && export LD_LIBRARY_PATH=../lib && ./example1
+
+./deps/hiredis/hiredis.h:
+	git submodule update --init deps/hiredis
 
 # ------------------------- DEBUG -------------------------------------
 

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1,10 +1,10 @@
 all:
-	$(MAKE) -C redis -f Makefile all
-	$(MAKE) -C hiredis -f Makefile all
+	$(MAKE) -C redis all
+	$(MAKE) -C hiredis all
 
 clean:
-	$(MAKE) -C redis -f Makefile clean
-	$(MAKE) -C hiredis -f Makefile all
+	$(MAKE) -C redis clean
+	$(MAKE) -C hiredis all
 
 
 .PHONY: all clean


### PR DESCRIPTION
This PR introduces a Makefile rule that ensures the hiredis dependency 
is present before the build process. Specifically, it checks for the existence 
of ./deps/hiredis/hiredis.h and, if missing, automatically initializes and 
updates the hiredis submodule by running the command:
```
git submodule update --init deps/hiredis
```
