### PR TITLE
Fix a test case matching an error message in PCRE library

### DIFF
--- a/test/test_rdb_cli.c
+++ b/test/test_rdb_cli.c
@@ -105,7 +105,7 @@ static void test_rdb_cli_filter_key(void **state) {
 static void test_rdb_cli_filter_invalid_input(void **state) {
     UNUSED(state);
     /* invalid regex */
-    runSystemCmd(" $RDB_CLI_CMD ./test/dumps/single_key.rdb -k \"[*x\" json | grep \"Unmatched \\[\" > /dev/null");
+    runSystemCmd(" $RDB_CLI_CMD ./test/dumps/single_key.rdb -k \"[*x\" json | grep \"FilterKey: Error compiling regular expression\" > /dev/null");
 }
 
 static void test_rdb_cli_filter_type(void **state) {


### PR DESCRIPTION
As mentioned in #57, the test case fails on macOS because of different implementation of libpcre may not emit the same message. It is in general not a good idea to match a specific error message defined in an external library. This can be mitigated by replacing the string with the general one that is defined directly in librdb.