### PR TITLE
Fix LFU Parsing for Values Larger Than 127

### DIFF
--- a/src/lib/parser.c
+++ b/src/lib/parser.c
@@ -1571,7 +1571,7 @@ RdbStatus elementFreq(RdbParser *p) {
 
     /*** ENTER SAFE STATE ***/
 
-    p->elmCtx.key.info.lfuFreq =  *((int8_t *) binfoFreq->ref);
+    p->elmCtx.key.info.lfuFreq =  *((uint8_t *) binfoFreq->ref);
     return nextParsingElement(p, PE_NEXT_RDB_TYPE);
 }
 


### PR DESCRIPTION
Corrected LFU parsing by casting to uint8 instead of int8 to handle values >127 properly.





