### PR TITLE
Update gitmodules; optimize CI Matrix; refine makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,46 +10,36 @@ jobs:
   build:
     strategy:
       matrix:
-        os:
-          - "ubuntu-latest"
-          - "macos-latest"
-        version:
-          - "5.0"
-          - "6.0"
-          - "6.2"
-          - "7.0"
-          - "7.2"
-          - "7.4"
-          - "unstable"
-        compiler:
-          - "gcc"
-          - "clang"
-
-        exclude:
-          - os: macos-latest
-            compiler: gcc
-          - os: macos-latest
-            version: "5.0"
-          - os: macos-latest
-            version: "6.0"
-          - os: macos-latest
-            version: "7.0"
+        - os: ubuntu-latest
+          compiler: gcc
+          version: "5.0"
+        - os: ubuntu-latest
+          compiler: clang
+          version: "6.0"
+        - os: ubuntu-latest
+          compiler: gcc
+          version: "7.0"
+        - os: ubuntu-latest
+          compiler: clang
+          version: "7.2"
+        - os: ubuntu-latest
+          compiler: gcc
+          version: "7.4"
+        - os: ubuntu-latest
+          compiler: clang
+          version: "unstable"
+        - os: macos-latest
+          compiler: gcc
+          version: "7.4"
+        - os: macos-latest
+          compiler: clang
+          version: "unstable"
 
     runs-on: ${{ matrix.os }}
 
     env:
       DEBIAN_FRONTEND: noninteractive
       CC: ${{ matrix.compiler }}
-
-    # TODO: would be nice to connect to a redis server instead of building from source
-    # services:
-    #   redis:
-    #     image: redis:${{ matrix.version }}
-    #     options: >-
-    #       --health-cmd "redis-cli ping"
-    #       --health-interval 10s
-    #       --health-timeout 5s
-    #       --health-retries 5
 
     steps:
       - name: Checkout librdb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,30 +10,31 @@ jobs:
   build:
     strategy:
       matrix:
-        - os: ubuntu-latest
-          compiler: gcc
-          version: "5.0"
-        - os: ubuntu-latest
-          compiler: clang
-          version: "6.0"
-        - os: ubuntu-latest
-          compiler: gcc
-          version: "7.0"
-        - os: ubuntu-latest
-          compiler: clang
-          version: "7.2"
-        - os: ubuntu-latest
-          compiler: gcc
-          version: "7.4"
-        - os: ubuntu-latest
-          compiler: clang
-          version: "unstable"
-        - os: macos-latest
-          compiler: gcc
-          version: "7.4"
-        - os: macos-latest
-          compiler: clang
-          version: "unstable"
+        include: 
+          - os: ubuntu-latest
+            compiler: gcc
+            version: "5.0"
+          - os: ubuntu-latest
+            compiler: clang
+            version: "6.0"
+          - os: ubuntu-latest
+            compiler: gcc
+            version: "7.0"
+          - os: ubuntu-latest
+            compiler: clang
+            version: "7.2"
+          - os: ubuntu-latest
+            compiler: gcc
+            version: "7.4"
+          - os: ubuntu-latest
+            compiler: clang
+            version: "unstable"
+          - os: macos-latest
+            compiler: gcc
+            version: "7.4"
+          - os: macos-latest
+            compiler: clang
+            version: "unstable"
 
     runs-on: ${{ matrix.os }}
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "deps/hiredis"]
 	path = deps/hiredis
 	url = https://github.com/redis/hiredis.git
+	branch = master

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,6 @@ clean:
 	rm -f librdb.pc
 	rm -f librdb-ext.pc
 
-distclean: clean
-
 example: all
 	cd examples && export LD_LIBRARY_PATH=../lib && ./example1
 
@@ -128,11 +126,10 @@ help:
 	@echo "    valgrind   - Run tests with static lib and valgrind"
 	@echo "    example    - Run the example"
 	@echo "    clean      - Clean without deps folders"
-	@echo "    distclean  - Clean including deps folders"
 	@echo "    install    - install to (DESTDIR)/(PREFIX)/bin and (DESTDIR)/(PREFIX)/lib"
 	@echo "                 By default PREFIX=/usr/local"
 	@echo "    uninstall  - Remove from (DESTDIR)\(PREFIX)/bin and (DESTDIR)/(PREFIX)/lib"
 	@echo "    help       - Prints this message"
 
 
-.PHONY: all debug test valgrind example clean distclean install uninstall build_test help
+.PHONY: all debug test valgrind example clean install uninstall build_test help

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -4,7 +4,7 @@ all:
 
 clean:
 	$(MAKE) -C redis clean
-	$(MAKE) -C hiredis all
+	$(MAKE) -C hiredis clean
 
 
 .PHONY: all clean

--- a/src/cli/Makefile
+++ b/src/cli/Makefile
@@ -2,11 +2,12 @@ default: all
 
 LIB_DIR               = ../../lib
 LIB_NAME              = rdb
-LIB_NAME_EXT          = $(LIB_NAME)-ext
+LIB_FILENAME          = librdb.a
+LIB_NAME_EXT          = rdb-ext
+LIB_FILENAME_EXT      = librdb-ext.a
 
 # Artifacts:
-TARGET_APP            = rdb-cli
-TARGET_LIB_STATIC_EXT = $(LIB_DIR)/lib$(LIB_NAME_EXT).a
+TARGET_APP           = rdb-cli
 
 #########################################################################################
 SOURCES  = $(notdir $(basename $(wildcard *.c)))
@@ -20,10 +21,15 @@ STACK       = -fstack-protector-all -Wstack-protector
 WARNS       = -Wall -Wextra -pedantic -Werror
 CFLAGS      = -fPIC $(OPTIMIZATION) $(STD) $(STACK) $(WARNS)
 DEBUG       = -g3 -DDEBUG=1
-LIBS        = -L /usr/lib -L $(LIB_DIR) -l $(LIB_NAME_EXT) -l $(LIB_NAME)
+
+ifeq ($(shell uname -s),Darwin)
+    LIBS = -L $(LIB_DIR) -l $(LIB_NAME_EXT) -l $(LIB_NAME)
+else
+    LIBS = -L $(LIB_DIR) -l:$(LIB_FILENAME) -l:$(LIB_FILENAME_EXT)
+endif
 
 ifeq ($(BUILD_TLS),yes)
-	CFLAGS += -DUSE_OPENSSL=1
+    CFLAGS+=-DUSE_OPENSSL=1
 	LIBS += -lssl -lcrypto
 endif
 
@@ -36,7 +42,7 @@ all: $(TARGET_APP)
 $(TARGET_APP): %: %.c lib_dependency
 	$(CC) $(CFLAGS) -o $@ $<  $(DEBUG) $(LIBS)
 
-lib_dependency: $(LIB_DIR)/lib$(LIB_NAME_EXT).a
+lib_dependency: $(LIB_DIR)/$(LIB_FILENAME_EXT)
 
 clean:
 	@rm -rvf $(TARGETS) ./*.o ../../bin/$(TARGET_APP)

--- a/src/cli/Makefile
+++ b/src/cli/Makefile
@@ -29,7 +29,7 @@ else
 endif
 
 ifeq ($(BUILD_TLS),yes)
-    CFLAGS+=-DUSE_OPENSSL=1
+	CFLAGS+=-DUSE_OPENSSL=1
 	LIBS += -lssl -lcrypto
 endif
 


### PR DESCRIPTION
- Simplifies the GitHub Actions CI matrix by replacing the full OS × Version × Compiler matrix with a more concise, targeted selection.
- Update .gitmodules to include branch explicitly of hiredis. 
- Refine makefile to ubuntu vs. macos 