### PR TITLE
Fix: Remove from Makefile tests redundant -L /usr/lib

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -21,8 +21,8 @@ OPTIMIZATION ?= -O0
 
 CFLAGS      = -D_DEFAULT_SOURCE -fPIC $(OPTIMIZATION) $(STD) $(STACK) $(WARNS)
 DEBUG       = -g3 -DDEBUG=1
-LIBS        = -l cmocka -L /usr/lib -L $(LIB_DIR) -l $(LIB_NAME) -l $(LIB_NAME_EXT) $(LIBHIREDIS)
-LIBS_STATIC = -l cmocka -L /usr/lib -L $(LIB_DIR) $(LIB_DIR)/lib$(LIB_NAME).a $(LIB_DIR)/lib$(LIB_NAME_EXT).a $(LIBHIREDIS)
+LIBS        = -l cmocka -L $(LIB_DIR) -l $(LIB_NAME) -l $(LIB_NAME_EXT) $(LIBHIREDIS)
+LIBS_STATIC = -l cmocka -L $(LIB_DIR) $(LIB_DIR)/lib$(LIB_NAME).a $(LIB_DIR)/lib$(LIB_NAME_EXT).a $(LIBHIREDIS)
 
 ifeq ($(BUILD_TLS),yes)
 	CFLAGS += -DUSE_OPENSSL=1


### PR DESCRIPTION
Might caused tests to consume installed librdb library rather than compiled one