### PR TITLE
Define LIBRDB_VERSION using a portable sed command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ else
 	PKGCONFIGDIR = $(LIBDIR)/pkgconfig
 endif
 
-LIBRDB_VERSION = $(shell grep -oP '(?<=LIBRDB_VERSION_STRING ")[0-9]+\.[0-9]+\.[0-9]+' ./src/lib/version.h)
+LIBRDB_VERSION = $(shell sed -n 's|^\#define LIBRDB_VERSION_STRING "\([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\)"|\1|p' ./src/lib/version.h)
 export LIBRDB_VERSION
 
 # ------------------------- ALL --------------------------------------


### PR DESCRIPTION
The 'grep -P' option is a GNU extension for Perl regular expressions. The default grep on BSD's and MacOS do not support this. This patch uses a simple 'sed' BRE that is portable anywhere.