### PR TITLE
Fix installation to custom directories.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
-PREFIX? = /usr/local
+PREFIX ?= /usr/local
 
-DESTDIR?=
+DESTDIR ?=
 INSTALL = /usr/bin/install -c
 BINDIR = $(DESTDIR)$(PREFIX)/bin
 LIBDIR = $(DESTDIR)$(PREFIX)/lib


### PR DESCRIPTION
Previously the Makefile variable 'PREFIX?' was defined which broke all subsequent definitions using $(PREFIX). This patch fixes the uses of the '?=' GNU Make operator.