### PR TITLE
Fix RDBX_writeFromCmdNumber() option and filtering

### DIFF
--- a/src/cli/rdb-cli.c
+++ b/src/cli/rdb-cli.c
@@ -313,7 +313,7 @@ static RdbRes formatResp(RdbParser *parser, int argc, char **argv) {
         if (getOptArg(argc, argv, &at, "-1", "--single-db", &(conf.singleDb), NULL)) continue;
         if (getOptArg(argc, argv, &at, "-t", "--target-redis-ver", NULL, &(conf.dstRedisVersion))) continue;
         if (getOptArg(argc, argv, &at, "-e", "--enum-commands", &commandEnum, NULL)) continue;
-        if (getOptArgVal(argc, argv, &at, "-n", "--start-cmd-num", NULL, &startCmdNum, 1, INT_MAX)) continue;
+        if (getOptArgVal(argc, argv, &at, "-s", "--start-cmd-num", NULL, &startCmdNum, 1, INT_MAX)) continue;
 
         loggerWrap(RDB_LOG_ERR, "Invalid 'resp' [FORMAT_OPTIONS] argument: %s\n", opt);
         printUsage(1);

--- a/src/cli/rdb-cli.c
+++ b/src/cli/rdb-cli.c
@@ -238,7 +238,7 @@ static RdbRes formatRedis(RdbParser *parser, int argc, char **argv) {
         if (getOptArg(argc, argv, &at, "-1", "--single-db", &(conf.singleDb), NULL)) continue;
         if (getOptArg(argc, argv, &at, "-t", "--target-redis-ver", NULL, &(conf.dstRedisVersion))) continue;
         if (getOptArgVal(argc, argv, &at, "-l", "--pipeline-depth", NULL, &pipeDepthVal, 1, 1000)) continue;
-        if (getOptArgVal(argc, argv, &at, "-n", "--start-cmd-num", NULL, &startCmdNum, 1, INT_MAX)) continue;
+        if (getOptArgVal(argc, argv, &at, "-s", "--start-cmd-num", NULL, &startCmdNum, 1, INT_MAX)) continue;
         if (getOptArg(argc, argv, &at, "-u", "--user", NULL, &auth.user)) continue;
         if (getOptArg(argc, argv, &at, "-P", "--password", NULL, &auth.pwd)) continue;
         if (getOptArg(argc, argv, &at, "-e", "--enum-commands", &commandEnum, NULL)) continue;

--- a/src/lib/parser.c
+++ b/src/lib/parser.c
@@ -846,15 +846,24 @@ static void resolveMultipleLevelsRegistration(RdbParser *p) {
 }
 
 static void attachDebugHandlers(RdbParser *p) {
+    int registered = 0;
     RDB_setLogLevel(p, RDB_LOG_DBG);
-    /* find the lowest level that handlers are registered and register DBG handlers accordingly */
+
+    /* Register debug handlers at all levels where there are existing handlers */
     if (p->numHandlers[RDB_LEVEL_RAW]) {
+        registered = 1;
         RdbHandlersRawCallbacks cb = {.handleNewKey = handleNewKeyPrintDbg, .handleEndKey = handleEndKeyPrintDbg};
         RDB_createHandlersRaw(p, &cb, NULL, NULL);
-    } else if (p->numHandlers[RDB_LEVEL_STRUCT]) {
+    }
+
+    if (p->numHandlers[RDB_LEVEL_STRUCT]) {
+        registered = 1;
         RdbHandlersStructCallbacks cb = {.handleNewKey = handleNewKeyPrintDbg, .handleEndKey = handleEndKeyPrintDbg};
         RDB_createHandlersStruct(p, &cb, NULL, NULL);
-    } else {
+    }
+    
+    /* If registerd at DATA level or if no handlers are registered at any level */
+    if ((p->numHandlers[RDB_LEVEL_DATA]) || (!registered)) {
         RdbHandlersDataCallbacks cb = {.handleNewKey = handleNewKeyPrintDbg, .handleEndKey = handleEndKeyPrintDbg};
         RDB_createHandlersData(p, &cb, NULL, NULL);
     }


### PR DESCRIPTION
* Fixed `--start-cmd-num` short option from `-n` to `-s` as expected.
* Fixed command filtering to properly handle RDB_OK_DONT_PROPAGATE when skipping commands
* Fixed debug printout functionality to be properly registered across all debug levels that registration of handlers was made.
* Added some comments to handlersToResp.c.

