### PR TITLE
Fix soft-links installation on non Darwin kernels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,6 @@
 
 PREFIX ?= /usr/local
 
-# Avoid the need for 'ln -r'.
-ifneq ($(realpath $(PREFIX)),$(PREFIX))
-$(error PREFIX must be a canonical path)
-endif
-
 DESTDIR ?=
 INSTALL = /usr/bin/install -c
 BINDIR = $(DESTDIR)$(PREFIX)/bin
@@ -15,6 +10,13 @@ LIBRDB_INSTALL_SHARED := yes
 LIBRDB_INSTALL_STATIC := yes
 
 UNAME := $(shell uname)
+
+# Set ln flags based on OS (macOS doesn't support -r flag)
+ifeq ($(UNAME),Darwin)
+	LN_FLAGS = -fs
+else
+	LN_FLAGS = -fsr
+endif
 
 ifneq (,$(filter $(UNAME),OpenBSD FreeBSD NetBSD))
 	PKGCONFIGDIR = $(DESTDIR)$(PREFIX)/libdata/pkgconfig
@@ -81,14 +83,14 @@ librdb-ext.pc: librdb-ext.pc.in Makefile
 install: all librdb.pc librdb-ext.pc
 	$(INSTALL) -d $(BINDIR)
 	$(INSTALL) -m 755 bin/rdb-cli $(BINDIR)/rdb-cli-$(LIBRDB_VERSION)
-	ln -fs $(BINDIR)/rdb-cli-$(LIBRDB_VERSION) $(BINDIR)/rdb-cli
+	ln $(LN_FLAGS) $(BINDIR)/rdb-cli-$(LIBRDB_VERSION) $(BINDIR)/rdb-cli
 	$(INSTALL) -d $(LIBDIR)
 
 ifeq ($(LIBRDB_INSTALL_SHARED),yes)
 	$(INSTALL) -m 755 lib/librdb.so.$(LIBRDB_VERSION) $(LIBDIR)/librdb.so.$(LIBRDB_VERSION)
-	ln -fs $(LIBDIR)/librdb.so.$(LIBRDB_VERSION) $(LIBDIR)/librdb.so
+	ln $(LN_FLAGS) $(LIBDIR)/librdb.so.$(LIBRDB_VERSION) $(LIBDIR)/librdb.so
 	$(INSTALL) -m 755 lib/librdb-ext.so.$(LIBRDB_VERSION) $(LIBDIR)/librdb-ext.so.$(LIBRDB_VERSION)
-	ln -fs $(LIBDIR)/librdb-ext.so.$(LIBRDB_VERSION) $(LIBDIR)/librdb-ext.so
+	ln $(LN_FLAGS) $(LIBDIR)/librdb-ext.so.$(LIBRDB_VERSION) $(LIBDIR)/librdb-ext.so
 	$(INSTALL) -d $(PKGCONFIGDIR)
 	$(INSTALL) -m 644 librdb.pc $(PKGCONFIGDIR)
 	$(INSTALL) -m 644 librdb-ext.pc $(PKGCONFIGDIR)
@@ -96,9 +98,9 @@ endif
 
 ifeq ($(LIBRDB_INSTALL_STATIC),yes)
 	$(INSTALL) -m 755 lib/librdb.a $(LIBDIR)/librdb.a.$(LIBRDB_VERSION)
-	ln -fs $(LIBDIR)/librdb.a.$(LIBRDB_VERSION) $(LIBDIR)/librdb.a
+	ln $(LN_FLAGS) $(LIBDIR)/librdb.a.$(LIBRDB_VERSION) $(LIBDIR)/librdb.a
 	$(INSTALL) -m 755 lib/librdb-ext.a $(LIBDIR)/librdb-ext.a.$(LIBRDB_VERSION)
-	ln -fs $(LIBDIR)/librdb-ext.a.$(LIBRDB_VERSION) $(LIBDIR)/librdb-ext.a
+	ln $(LN_FLAGS) $(LIBDIR)/librdb-ext.a.$(LIBRDB_VERSION) $(LIBDIR)/librdb-ext.a
 endif
 
 	$(INSTALL) -d $(INCDIR)


### PR DESCRIPTION
Following #75 , the link commands were modified from relative to absolute for the sake of macOS.
This PR reverts the change to be relative for non Darwin kernels.