### PR TITLE
Mark hashed key in error log with sha256: prefix

### DIFF
--- a/api/librdb-api.h
+++ b/api/librdb-api.h
@@ -494,8 +494,9 @@ _LIBRDB_API void RDB_log(RdbParser *p, RdbLogLevel lvl, const char *format, ...)
 _LIBRDB_API void RDB_log(RdbParser *p, RdbLogLevel lvl, const char *format, ...);
 #endif
 
-/* To hide keys in logs by printing first 8 hex digits of SHA256(key) instead of 
- * printing the key itself */
+/* To hide keys in logs by printing "sha256:" followed by the first 8 hex digits
+ * of SHA256(key), instead of the key itself. The prefix makes it explicit to
+ * log readers that the value is a digest, not the actual key. */
 _LIBRDB_API void RDB_hideKeysInLog(RdbParser *p);
 
 /****************************************************************

--- a/src/ext/extCommon.h
+++ b/src/ext/extCommon.h
@@ -51,6 +51,6 @@ static inline void iov_plain(struct iovec *iov, const char *s, size_t l) {
 }
 
 /*** hidden LIB API function (not declared in librdb-api.h) ***/
-_LIBRDB_API char *__RDB_key(RdbParser *p, char *key, char buf[9]);
+_LIBRDB_API char *__RDB_key(RdbParser *p, char *key, char buf[16]);
 
 #endif /*define RDBX_COMMON_H*/

--- a/src/ext/respToRedisLoader.c
+++ b/src/ext/respToRedisLoader.c
@@ -88,7 +88,7 @@ static int onReadRepliesErrorCb(void *context, char *msg) {
         (strstr(msg, "not found")))              /* error includes "not found" */
         return 0; /* mask error */
 
-    char buf[9];
+    char buf[16];
     RDB_reportError(ctx->p, (RdbRes) RDBX_ERR_RESP_WRITE,
                     "\nerror from dst '-%s' on key '%s' on command '%s' (RESP Command #%zu)\n",
                     msg,

--- a/src/lib/parser.c
+++ b/src/lib/parser.c
@@ -194,7 +194,7 @@ static RdbStatus readRdbWaitMoreDataDbg(RdbParser *p, size_t len, AllocTypeRq ty
 
 /*** hidden LIB API function (not declared in librdb-api.h) ***/
 
-_LIBRDB_API char *__RDB_key(RdbParser *p, char *key, char buf[9]) {
+_LIBRDB_API char *__RDB_key(RdbParser *p, char *key, char buf[16]) {
     if (!(p->hideKeysInLog)) return key;
 
     BYTE hash[SHA256_BLOCK_SIZE];
@@ -203,9 +203,12 @@ _LIBRDB_API char *__RDB_key(RdbParser *p, char *key, char buf[9]) {
     sha256_update(&ctx, (unsigned char*) key, strlen(key));
     sha256_final(&ctx, hash);
 
+    /* Prefix the hex digest so log readers can tell the value is a hash and not
+     * the actual key. Output: "sha256:" + 8 hex chars + NUL = 16 bytes. */
+    memcpy(buf, "sha256:", 7);
     for (int i = 0; i < 4; i++)
-        snprintf(buf + (i * 2), 3, "%02x", hash[i]);
-    buf[8] = '\0';
+        snprintf(buf + 7 + (i * 2), 3, "%02x", hash[i]);
+    buf[15] = '\0';
     return buf;
 }
 

--- a/test/test_rdb_to_redis.c
+++ b/test/test_rdb_to_redis.c
@@ -586,8 +586,9 @@ static void test_rdb_to_redis_del_before_write(void **state) {
 
 /* This test verifies the behavior of the RDB parser when the `hideKeysInLog`
  * option is set. Specifically, it ensures that keys in error messages are
- * replaced with the first 8 hex digits of their SHA256 hash, rather than being
- * logged directly.
+ * replaced with "sha256:" followed by the first 8 hex digits of their SHA256
+ * hash, rather than being logged directly. The "sha256:" prefix makes it
+ * explicit to log readers that the value is a digest, not the actual key.
  */
 static void test_rdb_to_redis_hide_keys_in_log(void **state) {
     UNUSED(state);
@@ -628,15 +629,15 @@ static void test_rdb_to_redis_hide_keys_in_log(void **state) {
     assert_int_equal(status, RDB_STATUS_ERROR);
     assert_int_equal(RDB_getErrorCode(p), RDBX_ERR_RESP_WRITE);
     
-    /* Expected to print first 8 hex digits of SHA256(key) instead of the key 
-     * itself. To eval via bash apply:
-     * > echo -n "mylist27" | sha256sum | cut -c 1-8 
+    /* Expected to print "sha256:" followed by first 8 hex digits of
+     * SHA256(key) instead of the key itself. To eval via bash apply:
+     * > echo -n "mylist27" | sha256sum | cut -c 1-8
      */
     printf("%s\n", RDB_getErrorMessage(p));
-    assert_non_null(strstr(RDB_getErrorMessage(p), "0bdab52c")); /* sha256("mylist27") */
-    
+    assert_non_null(strstr(RDB_getErrorMessage(p), "sha256:0bdab52c")); /* sha256("mylist27") */
+
     /* Verify that the key is not in the log */
-    assert_null(strstr(RDB_getErrorMessage(p), "mylist27"));    
+    assert_null(strstr(RDB_getErrorMessage(p), "mylist27"));
     
     RDB_deleteParser(p);
 }


### PR DESCRIPTION
When hideKeysInLog is enabled, error messages from respToRedisLoader print the first 8 hex chars of SHA256(key). To readers of the log this looks like an opaque token and can easily be mistaken for the actual key. Prefix the digest with "sha256:" so the value is self-describing.

The buffer in __RDB_key() and at its single caller widens from 9 to 16 bytes (7 prefix + 8 hex + NUL). The flag default is unchanged, so behavior is identical for any consumer that does not enable hideKeysInLog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes formatting of redacted key strings in logs when `RDB_hideKeysInLog()` is enabled, plus a small internal buffer size increase and test updates.
> 
> **Overview**
> When `hideKeysInLog` is enabled, redacted keys in error logs are now emitted as `sha256:<8 hex>` instead of just the 8-hex digest, making it explicit that the value is a hash.
> 
> This updates the internal `__RDB_key()` helper (and its single caller in `respToRedisLoader.c`) to add the prefix and widens the temporary buffer accordingly, and adjusts API comments and the corresponding test expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51d2cd125cbe1fec30810e1f7a624fc6d6253502. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->