### PR TITLE
Release version 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## [2.3.0] - 2026-06-03
 
 ### New Features
 - **RDB v14 Support — Stream XNACK (`RDB_TYPE_STREAM_LISTPACKS_5`)**:

--- a/src/version.h
+++ b/src/version.h
@@ -3,10 +3,10 @@
 
 /* Library Version Information */
 #define LIBRDB_MAJOR_VERSION 2
-#define LIBRDB_MINOR_VERSION 2
+#define LIBRDB_MINOR_VERSION 3
 #define LIBRDB_PATCH_VERSION 0
 
 /* Keep direct value for external readers */
-#define LIBRDB_VERSION_STRING "2.2.0"
+#define LIBRDB_VERSION_STRING "2.3.0"
 
 #endif /* LIBRDB_VERSION_H */


### PR DESCRIPTION

### New Features
- **RDB v14 Support — Stream XNACK (`RDB_TYPE_STREAM_LISTPACKS_5`)**:
  parse and emit the per-consumer-group NACK zone added in Redis 8.8.
  - New callback `handleStreamNackZoneEntry` on
    `RdbHandlersDataCallbacks`, fired once per NACKed stream ID after
    the consumers section of each consumer group.
- **RDB v14 Support — Array (`RDB_TYPE_ARRAY`)**: parse and emit the
  new top-level type added in Redis 8.8.
  - API additions (all additive, ABI-compatible):
    `RDB_DATA_TYPE_ARRAY` enum value, `handleArrayMetadata` /
    `handleArrayElement` callbacks on `RdbHandlersDataCallbacks`,
    `RDB_ARRAY_INSERT_IDX_NONE` sentinel (= `UINT64_MAX`), and
    `RDB_ERR_ARRAY_INVALID_STATE` error code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only changes with no runtime code modifications in this diff.
> 
> **Overview**
> **Release 2.3.0** — bumps the library version in `src/version.h` from **2.2.0** to **2.3.0** (`LIBRDB_MINOR_VERSION` 2→3, `LIBRDB_VERSION_STRING` updated) and moves the unreleased changelog entry to **`## [2.3.0] - 2026-06-03`**, documenting RDB v14 support (stream XNACK / `RDB_TYPE_STREAM_LISTPACKS_5`, array type / `RDB_TYPE_ARRAY`) and the associated additive callbacks and error codes described in the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 473c817e1d64c2eed6206155b3f3cd3ff51bbcd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->