### PR TITLE
Retry RESP loader socket writes on send timeout

### DIFF
--- a/runtests
+++ b/runtests
@@ -4,6 +4,7 @@ VALGRIND=0
 REDIS_FOLDER=""
 SPECIFIC_TEST=""
 SPECIFIC_TEST_GROUP=""
+SLOW_TESTS=""
 
 # Function to colorize test output
 colorize_output() {
@@ -30,8 +31,11 @@ while [[ $# -gt 0 ]]; do
     -g|--test-group)
       SPECIFIC_TEST_GROUP=" --test-group $2 "
       shift 2 ;;
+    -s|--slow-tests)
+      SLOW_TESTS=" --slow-tests "
+      shift ;;
     *|-h)
-      echo "Usage: $(basename $0) [-v|--valgrind] [-f|--folder REDIS_FOLDER] [-t|--test TEST] [-g|--test-group GROUP]"
+      echo "Usage: $(basename $0) [-v|--valgrind] [-f|--folder REDIS_FOLDER] [-t|--test TEST] [-g|--test-group GROUP] [-s|--slow-tests]"
       exit 1 ;;
   esac
 done
@@ -45,7 +49,7 @@ if [[ ${VALGRIND} -ne 0 ]]; then
   		--leak-resolution=high \
   		--error-exitcode=1 \
   		--log-file=test/log/valgrind.log \
-  		./test/test_static_lib -v $REDIS_FOLDER $SPECIFIC_TEST $SPECIFIC_TEST_GROUP 2>&1 | colorize_output
+  		./test/test_static_lib -v $REDIS_FOLDER $SPECIFIC_TEST $SPECIFIC_TEST_GROUP $SLOW_TESTS 2>&1 | colorize_output
 
   if [ ${PIPESTATUS[0]} -ne 0 ]; then
     sed -n -e '/SUMMARY:/,$p' ./test/log/valgrind.log | tail -n 20
@@ -54,6 +58,6 @@ if [[ ${VALGRIND} -ne 0 ]]; then
   fi
 
 else
-  ./test/test_lib $REDIS_FOLDER $SPECIFIC_TEST $SPECIFIC_TEST_GROUP 2>&1 | colorize_output
+  ./test/test_lib $REDIS_FOLDER $SPECIFIC_TEST $SPECIFIC_TEST_GROUP $SLOW_TESTS 2>&1 | colorize_output
   exit ${PIPESTATUS[0]}
 fi

--- a/src/ext/respToRedisLoader.c
+++ b/src/ext/respToRedisLoader.c
@@ -35,7 +35,10 @@
 #define REPLY_BUFF_SIZE             1024  /* reply buffer size */
 
 #define MAX_EINTR_RETRY             5
-#define RECV_CMD_TIMEOUT_SEC        10    /* recv() command timeout in seconds */
+#define RECV_CMD_TIMEOUT_SEC        10    /* recv()/send() command timeout in seconds */
+#define MAX_WRITE_STALL_RETRY       12    /* fail after this many consecutive send() timeouts
+                                             with zero progress (MAX_WRITE_STALL_RETRY *
+                                             RECV_CMD_TIMEOUT_SEC seconds of no drain) */
 
 struct RdbxRespToRedisLoader {
 
@@ -206,6 +209,11 @@ static ssize_t writevSSL(SSL *ssl, struct iovec *iov, int iovCnt) {
         if (sent <= 0) {
             int ssl_err = SSL_get_error(ssl, sent);
             if (ssl_err == SSL_ERROR_WANT_WRITE || ssl_err == SSL_ERROR_WANT_READ) {
+                /* Report bytes already sent so the caller advances past them and
+                 * the retry re-issues SSL_write() with the SAME buffer (OpenSSL
+                 * requires it). Only a block on the first entry returns EAGAIN. */
+                if (totalWritten > 0)
+                    return totalWritten;
                 errno = EAGAIN;
             } else {
                 errno = EIO;
@@ -226,6 +234,7 @@ static int redisLoaderWritev(void *context, struct iovec *iov, int iovCnt,
 {
     ssize_t writeResult;
     int retries = 0;
+    int stallRetries = 0;
 
     RdbxRespToRedisLoader *ctx = context;
 
@@ -257,12 +266,35 @@ static int redisLoaderWritev(void *context, struct iovec *iov, int iovCnt,
                     break;
                 }
                 continue;
+            } else if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                /* send() hit SO_SNDTIMEO with no bytes drained. A live server
+                 * keeps draining while we stream a command, so a sustained
+                 * zero-progress stall means it is stuck: bound the number of
+                 * *consecutive* no-progress windows (reset on any progress). */
+                if ((++stallRetries) >= MAX_WRITE_STALL_RETRY) {
+                    RDB_reportError(ctx->p, (RdbRes) RDBX_ERR_RESP2REDIS_FAILED_WRITE,
+                                    "Failed to write socket. Server not draining for %d seconds",
+                                    MAX_WRITE_STALL_RETRY * RECV_CMD_TIMEOUT_SEC);
+                    break;
+                }
+                RDB_log(ctx->p, RDB_LOG_INF,
+                        "Redis server not accepting writes for %d seconds",
+                        stallRetries * RECV_CMD_TIMEOUT_SEC);
+
+                /* Parser got external error? Currently used only for testing */
+                if (RDB_getErrorCode(ctx->p) != RDB_OK)
+                    break;
+
+                continue;
             } else {
                 RDB_reportError(ctx->p, (RdbRes) RDBX_ERR_RESP2REDIS_FAILED_WRITE,
                                 "Failed to write socket (errno=%d)", errno);
                 break;
             }
         }
+
+        retries = stallRetries = 0; /* progress made: reset EINTR and stall counters
+                                       so only *consecutive* interruptions count */
 
         /* crunch iov entries that were transmitted entirely */
         while ((iovCnt) && (iov->iov_len <= (size_t) writeResult)) {
@@ -438,9 +470,12 @@ _LIBRDB_API RdbxRespToRedisLoader *RDBX_createRespToRedisFd(RdbParser *p,
         return NULL;
     }
 
-    /* Set receive timeout (blocking, but with a limit) */
+    /* Set send/receive timeouts (blocking, but with a limit) so that a busy
+     * server which stops draining or replying is retried rather than blocking
+     * forever. See redisLoaderWritev()/readReplies() for the retry loops. */
     struct timeval timeout = { .tv_sec = RECV_CMD_TIMEOUT_SEC, .tv_usec = 0 };
-    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0) {
+    if ((setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0) ||
+        (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) < 0)) {
         RDB_reportError(p, (RdbRes) RDBX_ERR_RESP2REDIS_SET_TIMEOUT,
                         "Failed to configure timeout for socket. errno=%d: %s",
                         errno, strerror(errno));
@@ -546,9 +581,10 @@ static int configureSocket(RdbParser *p, int sockfd, int *origSockFlags) {
         return -1;
     }
 
-    /* Set receive timeout */
+    /* Set send/receive timeouts (see RDBX_createRespToRedisFd) */
     struct timeval timeout = { .tv_sec = RECV_CMD_TIMEOUT_SEC, .tv_usec = 0 };
-    if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0) {
+    if ((setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0) ||
+        (setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) < 0)) {
         RDB_reportError(p, (RdbRes) RDBX_ERR_RESP2REDIS_SET_TIMEOUT,
                         "Failed to set socket timeout. errno=%d: %s", errno, strerror(errno));
         return -1;

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -26,6 +26,7 @@
 #define RDB_CLI_VALGRIND_CMD       "/usr/bin/valgrind --track-origins=yes --leak-check=full --leak-resolution=high --error-exitcode=1 --log-file="RDB_CLI_VALGRIND_LOG_FILE" "RDB_CLI_CMD
 
 int          useValgrind = 0;
+int          runSlowTests = 0;
 int          currRedisInst = -1;
 redisContext *redisServersStack[MAX_NUM_REDIS_INST] = {0};
 int          redisPort[MAX_NUM_REDIS_INST]= {0};
@@ -536,6 +537,14 @@ int getRedisTlsPort(void) {
 
 void setValgrind(void) {
     useValgrind = 1;
+}
+
+void setRunSlowTests(void) {
+    runSlowTests = 1;
+}
+
+int isRunSlowTests(void) {
+    return runSlowTests;
 }
 
 /* Setup Redis server with TLS enabled - returns 1 on success, 0 on failure

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -44,6 +44,8 @@ void setRedisInstallFolder(const char *path);
 int getRedisPort(void);
 int getRedisTlsPort(void); /* Get TLS port (only valid after setupRedisServerTls) */
 void setValgrind(void);
+void setRunSlowTests(void);
+int isRunSlowTests(void); /* long-running tests run only when --slow-tests is passed */
 int setupRedisServer(const char *extraArgs, int useTls); /* Returns 1 on success, 0 on failure */
 const char *getTargetRedisVersion(int *major, int *minor); /* call only after setupRedisServer() */
 void teardownRedisServer(void);

--- a/test/test_main.c
+++ b/test/test_main.c
@@ -291,7 +291,8 @@ int main(int argc, char *argv[]) {
                         "  -f, --redis-folder <folder>      Specify the Redis folder to use for the tests\n"
                         "  -g, --test-group <group-prefix>  Selected test group to run\n"
                         "  -t, --test <filter>              Selected test to run\n"
-                        "  -v, --valgrind                   Run tests under valgrind";
+                        "  -v, --valgrind                   Run tests under valgrind\n"
+                        "  -s, --slow-tests                 Also run long-running tests (e.g. socket timeout/retry)";
 
 
 
@@ -308,6 +309,8 @@ int main(int argc, char *argv[]) {
             testFilter = argv[++i];
         } else if ((strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--valgrind") == 0)) {
             setValgrind();
+        } else if ((strcmp(argv[i], "-s") == 0 || strcmp(argv[i], "--slow-tests") == 0)) {
+            setRunSlowTests();
         } else {
             printf("Invalid argument: %s\n%s\n", argv[i], USAGE);
             exit(EXIT_FAILURE);

--- a/test/test_rdb_to_redis.c
+++ b/test/test_rdb_to_redis.c
@@ -743,38 +743,52 @@ static void test_rdb_to_redis_func_lib_replace_if_exist(void **state) {
  * the parser retries after TIMEOUT_SECONDS. Not part of CI since it takes to long */
 int countdownRetries;
 RdbParser *parser;
+
+/* Start a dummy TCP server on 127.0.0.1; returns the listening fd and fills
+ * *port. rcvbuf>0 shrinks SO_RCVBUF (so a writer blocks quickly). */
+static int startDummyServer(int *port, int rcvbuf) {
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    assert_true(fd >= 0);
+    int opt = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+    if (rcvbuf > 0)
+        setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf));
+    struct sockaddr_in a = { .sin_family = AF_INET,
+                             .sin_addr.s_addr = inet_addr("127.0.0.1"),
+                             .sin_port = htons(0) };
+    assert_int_equal(bind(fd, (struct sockaddr *)&a, sizeof(a)), 0);
+    socklen_t len = sizeof(a);
+    assert_int_equal(getsockname(fd, (struct sockaddr *)&a, &len), 0);
+    *port = ntohs(a.sin_port);
+    assert_int_equal(listen(fd, 1), 0);
+    printf("Dummy TCP server started on port %d\n", *port);
+    return fd;
+}
+
+/* Shared by the recv-side (test_rdb_tcp_timeout) and send-side
+ * (test_rdb_tcp_write_timeout) tests; each emits only its own retry message. */
 void dummyTcpTimeoutLogger(RdbLogLevel l, const char *msg) {
     UNUSED(l);
-    if (strstr(msg, "No reply from redis-server for") != NULL)
+    if (strstr(msg, "No reply from redis-server for") != NULL ||
+        strstr(msg, "Redis server not accepting writes for") != NULL)
         if (--countdownRetries == 0)
             RDB_reportError(parser, (RdbRes)12345678, "Inject error to end the test");
 }
 void test_rdb_tcp_timeout(void **state) {
     UNUSED(state);
+    if (!isRunSlowTests()) skip(); /* long-running; enable with --slow-tests */
     const int RECV_TIMEOUT_SECONDS = 10; /* socket retry timeout */
     int test_retries = 3; /* limit test to finite number of retries */
-    int server_fd, client_fd;
-    struct sockaddr_in server_addr, client_addr;
+    int client_fd;
+    struct sockaddr_in client_addr;
     socklen_t client_len = sizeof(client_addr);
 
     /* expected to retry 3 times before ending the test */
     countdownRetries = test_retries;
 
     /* Dummy TCP server that only receives messages but does not respond */
-    server_fd = socket(AF_INET, SOCK_STREAM, 0);
-    assert_true(server_fd >= 0);
-
-    int opt = 1;
-    setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_addr.s_addr = INADDR_ANY;
-    server_addr.sin_port = htons(0);
-    assert_int_equal(bind(server_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), 0);
-    socklen_t addr_len = sizeof(server_addr);
-    assert_int_equal(getsockname(server_fd, (struct sockaddr *)&server_addr, &addr_len), 0);
-    int assigned_port = ntohs(server_addr.sin_port);
-    assert_int_equal(listen(server_fd, 1), 0);
-    printf("Dummy TCP server started, waiting for client to connect...\n");
+    int assigned_port;
+    int server_fd = startDummyServer(&assigned_port, 0);
 
     parser = RDB_createParserRdb(NULL);
     RDB_setLogLevel(parser, RDB_LOG_INF);
@@ -807,6 +821,77 @@ void test_rdb_tcp_timeout(void **state) {
     int expectedTime = RECV_TIMEOUT_SECONDS * test_retries;
     printf("Elapsed time: %ld, expected time: %d\n", elapsedTime, expectedTime);
     assert_in_range(elapsedTime, expectedTime - 2, expectedTime + 2);
+
+    RDB_deleteParser(parser);
+    close(client_fd);
+    close(server_fd);
+}
+
+/* Create dummy TCP server that accepts a connection but never reads from it, so
+ * the client's send buffer fills and send() keeps timing out on SO_SNDTIMEO.
+ * Verify that redisLoaderWritev() retries on the stall (mirror of the recv side
+ * tested by test_rdb_tcp_timeout). Both the client send buffer and the server
+ * receive buffer are shrunk so a moderate key is enough to block the writer.
+ * Not part of CI since it takes too long. */
+void test_rdb_tcp_write_timeout(void **state) {
+    UNUSED(state);
+    if (!isRunSlowTests()) skip(); /* long-running; enable with --slow-tests */
+    int test_retries = 3; /* end via injected error before MAX_WRITE_STALL_RETRY (12) */
+    int client_fd, conn_fd;
+    struct sockaddr_in server_addr, client_addr;
+    socklen_t client_len = sizeof(client_addr);
+
+    /* expected to retry 3 times before ending the test */
+    countdownRetries = test_retries;
+
+    /* Dummy TCP server that accepts the connection but never reads from it.
+     * Shrink its receive buffer so the writer blocks quickly. */
+    int assigned_port;
+    int server_fd = startDummyServer(&assigned_port, 1024);
+
+    /* Client socket with a tiny send buffer, connected ourselves so we control
+     * the buffer size, then handed to librdb via RDBX_createRespToRedisFd(). */
+    conn_fd = socket(AF_INET, SOCK_STREAM, 0);
+    assert_true(conn_fd >= 0);
+    int sndbuf = 1024;
+    setsockopt(conn_fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+    server_addr.sin_port = htons(assigned_port);
+    assert_int_equal(connect(conn_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)), 0);
+
+    client_fd = accept(server_fd, (struct sockaddr *)&client_addr, &client_len);
+    assert_true(client_fd >= 0);
+    /* Intentionally never recv() from client_fd */
+
+    parser = RDB_createParserRdb(NULL);
+    RDB_setLogLevel(parser, RDB_LOG_INF);
+    RDB_setLogger(parser, dummyTcpTimeoutLogger);
+    /* A key big enough to overflow the socket buffers and block the writer */
+    assert_non_null(RDBX_createReaderFile(parser, DUMP_FOLDER("100_lists.rdb")));
+
+    RdbxToRespConf rdb2respConf = {
+            .supportRestore = 1,
+            .dstRedisVersion = getTargetRedisVersion(NULL, NULL),
+            .supportRestoreModuleAux = isSupportRestoreModuleAux()
+    };
+
+    RdbxToResp *rdbToResp;
+    RdbxRespToRedisLoader *r2r;
+    assert_non_null(rdbToResp = RDBX_createHandlersToResp(parser, &rdb2respConf));
+    assert_non_null(r2r = RDBX_createRespToRedisFd(parser, rdbToResp, NULL, conn_fd));
+
+    /* Avoid reading replies mid-stream so the writer is the one that stalls */
+    RDBX_setPipelineDepth(r2r, 1000);
+
+    /* Run parser. Expected to hit SO_SNDTIMEO and retry the write test_retries
+     * times, logging each time, before the logger injects an error to stop it. */
+    RdbStatus status;
+    while ((status = RDB_parse(parser)) == RDB_STATUS_WAIT_MORE_DATA);
+
+    /* Error code is only set after test_retries write-timeout retries, so this
+     * proves the writer retried instead of aborting on the first EAGAIN. */
+    assert_int_equal(RDB_getErrorCode(parser), 12345678);
 
     RDB_deleteParser(parser);
     close(client_fd);
@@ -910,7 +995,8 @@ int group_rdb_to_redis(void) {
             cmocka_unit_test_setup(test_rdb_to_redis_script, setupTest),
             cmocka_unit_test_setup(test_rdb_to_redis_script_legacy, setupTest),
             cmocka_unit_test_setup(test_rdb_to_redis_ipv6_localhost, setupTest),
-            //cmocka_unit_test_setup(test_rdb_tcp_timeout, setupTest), /* too long to run */
+            cmocka_unit_test_setup(test_rdb_tcp_timeout, setupTest),      /* slow; --slow-tests */
+            cmocka_unit_test_setup(test_rdb_tcp_write_timeout, setupTest),/* slow; --slow-tests */
     };
 
     int res = cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
## Problem

Syncing a big key (`RESTORE` of several GB) can stall the **send** side when the
destination briefly stops draining the socket (e.g. multi-GB query-buffer
reallocs). `redisLoaderWritev()` aborted on the first `EAGAIN`, failing the
whole sync with `RDBX_ERR_RESP2REDIS_FAILED_WRITE`. This mirrors the recv-side
issue fixed in #69, but on the write path.

## Fix

- Set `SO_SNDTIMEO` alongside `SO_RCVTIMEO` so a stalled send returns instead of
  blocking forever.
- On `EAGAIN`/`EWOULDBLOCK`, retry with logging; **reset the counter on any
  progress** so a slow-but-alive transfer runs unbounded, and fail only after
  `MAX_WRITE_STALL_RETRY` consecutive zero-progress windows (a dead peer).
- `EINTR` retries also reset on progress (only *consecutive* interruptions count).
- `writevSSL()` reports partial progress so the retry re-issues `SSL_write()`
  with the same buffer (OpenSSL requirement), avoiding duplicated bytes.

## Tests

Adds `test_rdb_tcp_write_timeout` (mirror of `test_rdb_tcp_timeout`). Both are
long-running and gated behind a new `--slow-tests` run argument:
`./runtests --slow-tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core RDB sync I/O for all TCP/TLS loaders; behavior is intentionally more tolerant of backpressure but could mask a truly stuck peer for up to ~2 minutes before failing.
> 
> **Overview**
> Large RDB→Redis syncs could fail when the destination briefly stops draining the TCP socket because **`redisLoaderWritev()`** treated the first send timeout as fatal. This PR mirrors the existing recv-side retry behavior on the **write** path.
> 
> **Loader behavior:** **`SO_SNDTIMEO`** is set with **`SO_RCVTIMEO`** on loader sockets. On **`EAGAIN`/`EWOULDBLOCK`**, the writer logs and retries; progress resets stall/EINTR counters so slow but healthy transfers can continue, while **`MAX_WRITE_STALL_RETRY`** consecutive zero-progress windows (~120s) fail with a clear error. **`writevSSL()`** returns partial bytes on **`WANT_READ`/`WANT_WRITE`** so retries use the same OpenSSL buffer semantics.
> 
> **Tests:** Adds **`test_rdb_tcp_write_timeout`** (non-reading peer + tiny buffers) and refactors the recv timeout test around **`startDummyServer`**. Both long tests are registered in CI but **skipped unless `--slow-tests`** (wired through **`runtests`**, **`test_main`**, and **`isRunSlowTests()`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b24feda2fb6c9865bb51ad0ba3730244b29554e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->